### PR TITLE
친구 관련 조회 기능 구현

### DIFF
--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -1,4 +1,5 @@
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
+import { FriendRequest } from 'src/domain/types/friend.types';
 import { User } from 'src/domain/types/user.types';
 import { UserPaginationInput } from 'src/shared/types';
 
@@ -9,6 +10,10 @@ export interface FriendsRepository {
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<User[]>;
+  findAllReceivedRequestByUserId(
+    userId: string,
+    paginationInput: UserPaginationInput,
+  ): Promise<FriendRequest[]>;
   update(id: string, data: Partial<FriendEntity>): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -1,13 +1,13 @@
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { User } from 'src/domain/types/user.types';
-import { PaginationInput } from 'src/shared/types';
+import { UserPaginationInput } from 'src/shared/types';
 
 export interface FriendsRepository {
   save(data: FriendEntity): Promise<void>;
   findOneById(id: string): Promise<{ id: string; receiverId: string } | null>;
   findAllFriendByUserId(
     userId: string,
-    paginationInput: PaginationInput,
+    paginationInput: UserPaginationInput,
   ): Promise<User[]>;
   update(id: string, data: Partial<FriendEntity>): Promise<void>;
   delete(id: string): Promise<void>;

--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -1,6 +1,7 @@
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FriendRequest } from 'src/domain/types/friend.types';
 import { User } from 'src/domain/types/user.types';
+import { SearchInput } from 'src/infrastructure/types/user.types';
 import { UserPaginationInput } from 'src/shared/types';
 
 export interface FriendsRepository {
@@ -9,6 +10,10 @@ export interface FriendsRepository {
   findFriendsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
+  ): Promise<User[]>;
+  findFriendsByAccountIdAndNameContaining(
+    userId: string,
+    searchInput: SearchInput,
   ): Promise<User[]>;
   findReceivedRequestsByUserId(
     userId: string,

--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -14,6 +14,10 @@ export interface FriendsRepository {
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<FriendRequest[]>;
+  findAllSentRequestByUserId(
+    userId: string,
+    paginationInput: UserPaginationInput,
+  ): Promise<FriendRequest[]>;
   update(id: string, data: Partial<FriendEntity>): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -1,8 +1,14 @@
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
+import { User } from 'src/domain/types/user.types';
+import { PaginationInput } from 'src/shared/types';
 
 export interface FriendsRepository {
   save(data: FriendEntity): Promise<void>;
   findOneById(id: string): Promise<{ id: string; receiverId: string } | null>;
+  findAllFriendByUserId(
+    userId: string,
+    paginationInput: PaginationInput,
+  ): Promise<User[]>;
   update(id: string, data: Partial<FriendEntity>): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -6,15 +6,15 @@ import { UserPaginationInput } from 'src/shared/types';
 export interface FriendsRepository {
   save(data: FriendEntity): Promise<void>;
   findOneById(id: string): Promise<{ id: string; receiverId: string } | null>;
-  findAllFriendByUserId(
+  findFriendsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<User[]>;
-  findAllReceivedRequestByUserId(
+  findReceivedRequestsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<FriendRequest[]>;
-  findAllSentRequestByUserId(
+  findSentRequestsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<FriendRequest[]>;

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -30,7 +30,7 @@ export class FriendsService {
       userId,
       paginationInput,
     );
-    const nextCursor = this.getCursor(users);
+    const nextCursor = this.getCursor(users, paginationInput.limit);
 
     return {
       users,
@@ -69,7 +69,7 @@ export class FriendsService {
     }
   }
 
-  getCursor(users: User[]): string | null {
-    return users.at(-1)?.name || null;
+  getCursor(users: User[], limit: number): string | null {
+    return users[limit - 1]?.name || null;
   }
 }

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -12,6 +12,8 @@ import {
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FriendsRepository } from 'src/domain/interface/friend/friends.repository';
 import { FriendPrototype } from 'src/domain/types/friend.types';
+import { PaginationInput } from 'src/shared/types';
+import { User } from 'src/domain/types/user.types';
 
 @Injectable()
 export class FriendsService {
@@ -19,6 +21,19 @@ export class FriendsService {
     @Inject(FriendsRepository)
     private readonly friendsRepository: FriendsRepository,
   ) {}
+
+  async getAllFriendByUserId(userId: string, paginationInput: PaginationInput) {
+    const users = await this.friendsRepository.findAllFriendByUserId(
+      userId,
+      paginationInput,
+    );
+    const nextCursor = this.getCursor(users);
+
+    return {
+      users,
+      nextCursor,
+    };
+  }
 
   async request(prototype: FriendPrototype) {
     const stdDate = new Date();
@@ -49,5 +64,9 @@ export class FriendsService {
     if (friendRequest.receiverId !== receiverId) {
       throw new ForbiddenException(FORBIDDEN_MESSAGE);
     }
+  }
+
+  getCursor(users: User[]): string | null {
+    return users.at(-1)?.name || null;
   }
 }

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -12,7 +12,7 @@ import {
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FriendsRepository } from 'src/domain/interface/friend/friends.repository';
 import { FriendPrototype } from 'src/domain/types/friend.types';
-import { PaginationInput } from 'src/shared/types';
+import { UserPaginationInput } from 'src/shared/types';
 import { User } from 'src/domain/types/user.types';
 
 @Injectable()
@@ -22,7 +22,10 @@ export class FriendsService {
     private readonly friendsRepository: FriendsRepository,
   ) {}
 
-  async getAllFriendByUserId(userId: string, paginationInput: PaginationInput) {
+  async getAllFriendByUserId(
+    userId: string,
+    paginationInput: UserPaginationInput,
+  ) {
     const users = await this.friendsRepository.findAllFriendByUserId(
       userId,
       paginationInput,

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -13,7 +13,7 @@ import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FriendsRepository } from 'src/domain/interface/friend/friends.repository';
 import { FriendPrototype } from 'src/domain/types/friend.types';
 import { UserPaginationInput } from 'src/shared/types';
-import { User } from 'src/domain/types/user.types';
+import { getUserCursor } from 'src/domain/shared/get-cursor';
 
 @Injectable()
 export class FriendsService {
@@ -22,7 +22,7 @@ export class FriendsService {
     private readonly friendsRepository: FriendsRepository,
   ) {}
 
-  async getAllFriendByUserId(
+  async getFriendsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
   ) {
@@ -30,7 +30,7 @@ export class FriendsService {
       userId,
       paginationInput,
     );
-    const nextCursor = this.getCursor(users, paginationInput.limit);
+    const nextCursor = getUserCursor(users, paginationInput.limit);
 
     return {
       users,
@@ -67,9 +67,5 @@ export class FriendsService {
     if (friendRequest.receiverId !== receiverId) {
       throw new ForbiddenException(FORBIDDEN_MESSAGE);
     }
-  }
-
-  getCursor(users: User[], limit: number): string | null {
-    return users[limit - 1]?.name || null;
   }
 }

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -13,7 +13,10 @@ import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FriendsRepository } from 'src/domain/interface/friend/friends.repository';
 import { FriendPrototype } from 'src/domain/types/friend.types';
 import { UserPaginationInput } from 'src/shared/types';
-import { getUserCursor } from 'src/domain/shared/get-cursor';
+import {
+  getFriendRequestCursor,
+  getUserCursor,
+} from 'src/domain/shared/get-cursor';
 
 @Injectable()
 export class FriendsService {
@@ -34,6 +37,23 @@ export class FriendsService {
 
     return {
       users,
+      nextCursor,
+    };
+  }
+
+  async getReceivedRequestsByUserId(
+    userId: string,
+    paginationInput: UserPaginationInput,
+  ) {
+    const requests =
+      await this.friendsRepository.findAllReceivedRequestByUserId(
+        userId,
+        paginationInput,
+      );
+    const nextCursor = getFriendRequestCursor(requests, paginationInput.limit);
+
+    return {
+      requests,
       nextCursor,
     };
   }

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -29,7 +29,7 @@ export class FriendsService {
     userId: string,
     paginationInput: UserPaginationInput,
   ) {
-    const users = await this.friendsRepository.findAllFriendByUserId(
+    const users = await this.friendsRepository.findFriendsByUserId(
       userId,
       paginationInput,
     );
@@ -45,11 +45,10 @@ export class FriendsService {
     userId: string,
     paginationInput: UserPaginationInput,
   ) {
-    const requests =
-      await this.friendsRepository.findAllReceivedRequestByUserId(
-        userId,
-        paginationInput,
-      );
+    const requests = await this.friendsRepository.findReceivedRequestsByUserId(
+      userId,
+      paginationInput,
+    );
     const nextCursor = getFriendRequestCursor(requests, paginationInput.limit);
 
     return {
@@ -62,11 +61,10 @@ export class FriendsService {
     userId: string,
     paginationInput: UserPaginationInput,
   ) {
-    const requests =
-      await this.friendsRepository.findAllReceivedRequestByUserId(
-        userId,
-        paginationInput,
-      );
+    const requests = await this.friendsRepository.findReceivedRequestsByUserId(
+      userId,
+      paginationInput,
+    );
     const nextCursor = getFriendRequestCursor(requests, paginationInput.limit);
 
     return {

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -17,6 +17,7 @@ import {
   getFriendRequestCursor,
   getUserCursor,
 } from 'src/domain/shared/get-cursor';
+import { SearchInput } from 'src/domain/types/user.types';
 
 @Injectable()
 export class FriendsService {
@@ -37,6 +38,21 @@ export class FriendsService {
 
     return {
       users,
+      nextCursor,
+    };
+  }
+
+  async search(userId: string, searchInput: SearchInput) {
+    const { search, paginationInput } = searchInput;
+    const searchedUsers =
+      await this.friendsRepository.findFriendsByAccountIdAndNameContaining(
+        userId,
+        { search, paginationInput },
+      );
+    const nextCursor = getUserCursor(searchedUsers, paginationInput.limit);
+
+    return {
+      users: searchedUsers,
       nextCursor,
     };
   }

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -58,6 +58,23 @@ export class FriendsService {
     };
   }
 
+  async getSentRequestsByUserId(
+    userId: string,
+    paginationInput: UserPaginationInput,
+  ) {
+    const requests =
+      await this.friendsRepository.findAllReceivedRequestByUserId(
+        userId,
+        paginationInput,
+      );
+    const nextCursor = getFriendRequestCursor(requests, paginationInput.limit);
+
+    return {
+      requests,
+      nextCursor,
+    };
+  }
+
   async request(prototype: FriendPrototype) {
     const stdDate = new Date();
     const friend = FriendEntity.create(prototype, v4, stdDate);

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -10,11 +10,12 @@ export class UsersService {
   ) {}
 
   async search(userId: string, searchInput: SearchInput) {
+    const { search, paginationInput } = searchInput;
     const searchedUsers = await this.usersRepository.findByAccountIdContaining(
       userId,
-      searchInput,
+      { search, paginationInput },
     );
-    const nextCursor = this.getCursor(searchedUsers);
+    const nextCursor = this.getCursor(searchedUsers, paginationInput.limit);
 
     return {
       users: searchedUsers,
@@ -22,7 +23,7 @@ export class UsersService {
     };
   }
 
-  getCursor(users: User[]) {
-    return users.at(-1)?.name || null;
+  getCursor(users: User[], limit: number): string | null {
+    return users[limit - 1]?.name || null;
   }
 }

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { UsersRepository } from 'src/domain/interface/users.repository';
-import { SearchInput, User } from 'src/domain/types/user.types';
+import { getUserCursor } from 'src/domain/shared/get-cursor';
+import { SearchInput } from 'src/domain/types/user.types';
 
 @Injectable()
 export class UsersService {
@@ -15,15 +16,11 @@ export class UsersService {
       userId,
       { search, paginationInput },
     );
-    const nextCursor = this.getCursor(searchedUsers, paginationInput.limit);
+    const nextCursor = getUserCursor(searchedUsers, paginationInput.limit);
 
     return {
       users: searchedUsers,
       nextCursor,
     };
-  }
-
-  getCursor(users: User[], limit: number): string | null {
-    return users[limit - 1]?.name || null;
   }
 }

--- a/src/domain/shared/get-cursor.ts
+++ b/src/domain/shared/get-cursor.ts
@@ -10,7 +10,7 @@ export const getUserCursor = (users: User[], limit: number) => {
     : null;
 };
 
-export const getFriendCursor = (
+export const getFriendRequestCursor = (
   friendRequests: FriendRequest[],
   limit: number,
 ) => {

--- a/src/domain/shared/get-cursor.ts
+++ b/src/domain/shared/get-cursor.ts
@@ -1,5 +1,23 @@
+import { FriendRequest } from 'src/domain/types/friend.types';
 import { User } from 'src/domain/types/user.types';
 
-export const getUserCursor = (users: User[], limit: number): string | null => {
-  return users[limit - 1]?.name || null;
+export const getUserCursor = (users: User[], limit: number) => {
+  return users[limit - 1]
+    ? {
+        name: users[limit - 1].name,
+        accountId: users[limit - 1].accountId,
+      }
+    : null;
+};
+
+export const getFriendCursor = (
+  friendRequests: FriendRequest[],
+  limit: number,
+) => {
+  return friendRequests[limit - 1]
+    ? {
+        name: friendRequests[limit - 1].sender.name,
+        accountId: friendRequests[limit - 1].sender.accountId,
+      }
+    : null;
 };

--- a/src/domain/shared/get-cursor.ts
+++ b/src/domain/shared/get-cursor.ts
@@ -1,0 +1,5 @@
+import { User } from 'src/domain/types/user.types';
+
+export const getUserCursor = (users: User[], limit: number): string | null => {
+  return users[limit - 1]?.name || null;
+};

--- a/src/domain/types/friend.types.ts
+++ b/src/domain/types/friend.types.ts
@@ -2,3 +2,15 @@ export interface FriendPrototype {
   readonly senderId: string;
   readonly receiverId: string;
 }
+
+export interface FriendRequest {
+  readonly id: string;
+  readonly sender: User;
+}
+
+interface User {
+  readonly id: string;
+  readonly accountId: string;
+  readonly name: string;
+  readonly profileImageUrl: string;
+}

--- a/src/domain/types/user.types.ts
+++ b/src/domain/types/user.types.ts
@@ -1,4 +1,4 @@
-import { PaginationInput, Provider } from 'src/shared/types';
+import { UserPaginationInput, Provider } from 'src/shared/types';
 
 export interface UserPrototype {
   readonly email: string;
@@ -22,6 +22,6 @@ export interface User {
 }
 
 export interface SearchInput {
-  paginationInput: PaginationInput;
+  paginationInput: UserPaginationInput;
   search: string;
 }

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -66,11 +66,21 @@ export class FriendsPrismaRepository implements FriendsRepository {
           .selectFrom('friend as f')
           .select('f.receiver_id as user_id')
           .where('f.sender_id', '=', userId)
+          .where(
+            'f.status',
+            '=',
+            sql<FriendStatus>`${FriendStatus.ACCEPTED}::"FriendStatus"`,
+          )
           .union((qb) =>
             qb
               .selectFrom('friend as f')
               .select('f.sender_id as user_id')
-              .where('f.receiver_id', '=', userId),
+              .where('f.receiver_id', '=', userId)
+              .where(
+                'f.status',
+                '=',
+                sql<FriendStatus>`${FriendStatus.ACCEPTED}::"FriendStatus"`,
+              ),
           ),
       )
       .orderBy('u.name')

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -3,7 +3,9 @@ import { Prisma } from '@prisma/client';
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FRIEND_REQUEST_ALREADY_EXIST_MESSAGE } from 'src/domain/error/messages';
 import { FriendsRepository } from 'src/domain/interface/friend/friends.repository';
+import { User } from 'src/domain/types/user.types';
 import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
+import { PaginationInput } from 'src/shared/types';
 
 @Injectable()
 export class FriendsPrismaRepository implements FriendsRepository {
@@ -37,6 +39,39 @@ export class FriendsPrismaRepository implements FriendsRepository {
         id,
       },
     });
+  }
+
+  async findAllFriendByUserId(
+    userId: string,
+    paginationInput: PaginationInput,
+  ): Promise<User[]> {
+    const rows = await this.prisma.$kysely
+      .selectFrom('user as u')
+      .select(['u.id', 'u.account_id', 'u.name', 'u.profile_image_url'])
+      .where('u.id', '!=', userId)
+      .where('u.name', '>', paginationInput.cursor)
+      .where('u.id', 'in', (qb) =>
+        qb
+          .selectFrom('friend as f')
+          .select('f.receiver_id as user_id')
+          .where('f.sender_id', '=', userId)
+          .union((qb) =>
+            qb
+              .selectFrom('friend as f')
+              .select('f.sender_id as user_id')
+              .where('f.receiver_id', '=', userId),
+          ),
+      )
+      .orderBy('u.name')
+      .limit(paginationInput.limit)
+      .execute();
+
+    return rows.map((row) => ({
+      id: row.id,
+      accountId: row.account_id,
+      name: row.name,
+      profileImageUrl: row.profile_image_url,
+    }));
   }
 
   async update(id: string, data: Partial<FriendEntity>): Promise<void> {

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -43,7 +43,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
     });
   }
 
-  async findAllFriendByUserId(
+  async findFriendsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<User[]> {
@@ -96,7 +96,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
     }));
   }
 
-  async findAllReceivedRequestByUserId(
+  async findReceivedRequestsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<FriendRequest[]> {
@@ -142,7 +142,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
     }));
   }
 
-  async findAllSentRequestByUserId(
+  async findSentRequestsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,
   ): Promise<FriendRequest[]> {

--- a/src/infrastructure/types/user.types.ts
+++ b/src/infrastructure/types/user.types.ts
@@ -1,6 +1,6 @@
-import { PaginationInput } from 'src/shared/types';
+import { UserPaginationInput } from 'src/shared/types';
 
 export interface SearchInput {
-  paginationInput: PaginationInput;
+  paginationInput: UserPaginationInput;
   search: string;
 }

--- a/src/presentation/controllers/friend/friends.controller.ts
+++ b/src/presentation/controllers/friend/friends.controller.ts
@@ -63,4 +63,15 @@ export class FriendsController {
       paginationDto,
     );
   }
+
+  @Get('requests/sent')
+  async getSentRequests(
+    @Query() paginationDto: UserPaginationRequest,
+    @CurrentUser() userId: string,
+  ): Promise<FriendRequestListResponse> {
+    return await this.friendsService.getSentRequestsByUserId(
+      userId,
+      paginationDto,
+    );
+  }
 }

--- a/src/presentation/controllers/friend/friends.controller.ts
+++ b/src/presentation/controllers/friend/friends.controller.ts
@@ -12,6 +12,7 @@ import { AuthGuard } from 'src/common/guards/auth.guard';
 import { FriendsService } from 'src/domain/services/friend/friends.service';
 import { CreateFriendRequest } from 'src/presentation/dto/friend/create-friend.request';
 import { FriendListResponse } from 'src/presentation/dto/friend/friend-list.response';
+import { FriendRequestListResponse } from 'src/presentation/dto/friend/friend-request-list.response';
 import { UserPaginationRequest } from 'src/presentation/dto/user/user-pagination.request';
 
 @UseGuards(AuthGuard)
@@ -49,7 +50,15 @@ export class FriendsController {
     @Query() paginationDto: UserPaginationRequest,
     @CurrentUser() userId: string,
   ): Promise<FriendListResponse> {
-    return await this.friendsService.getAllFriendByUserId(
+    return await this.friendsService.getFriendsByUserId(userId, paginationDto);
+  }
+
+  @Get('requests/received')
+  async getReceivedRequests(
+    @Query() paginationDto: UserPaginationRequest,
+    @CurrentUser() userId: string,
+  ): Promise<FriendRequestListResponse> {
+    return await this.friendsService.getReceivedRequestsByUserId(
       userId,
       paginationDto,
     );

--- a/src/presentation/controllers/friend/friends.controller.ts
+++ b/src/presentation/controllers/friend/friends.controller.ts
@@ -1,8 +1,18 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { FriendsService } from 'src/domain/services/friend/friends.service';
 import { CreateFriendRequest } from 'src/presentation/dto/friend/create-friend.request';
+import { FriendListResponse } from 'src/presentation/dto/friend/friend-list.response';
+import { UserPaginationRequest } from 'src/presentation/dto/user/user-pagination.request';
 
 @UseGuards(AuthGuard)
 @Controller('friends')
@@ -32,5 +42,16 @@ export class FriendsController {
     @CurrentUser() userId: string,
   ) {
     await this.friendsService.reject(friendId, userId);
+  }
+
+  @Get()
+  async getAllFriend(
+    @Query() paginationDto: UserPaginationRequest,
+    @CurrentUser() userId: string,
+  ): Promise<FriendListResponse> {
+    return await this.friendsService.getAllFriendByUserId(
+      userId,
+      paginationDto,
+    );
   }
 }

--- a/src/presentation/controllers/friend/friends.controller.ts
+++ b/src/presentation/controllers/friend/friends.controller.ts
@@ -45,7 +45,7 @@ export class FriendsController {
   }
 
   @Get()
-  async getAllFriend(
+  async getFriends(
     @Query() paginationDto: UserPaginationRequest,
     @CurrentUser() userId: string,
   ): Promise<FriendListResponse> {

--- a/src/presentation/controllers/friend/friends.controller.ts
+++ b/src/presentation/controllers/friend/friends.controller.ts
@@ -13,6 +13,7 @@ import { FriendsService } from 'src/domain/services/friend/friends.service';
 import { CreateFriendRequest } from 'src/presentation/dto/friend/create-friend.request';
 import { FriendListResponse } from 'src/presentation/dto/friend/friend-list.response';
 import { FriendRequestListResponse } from 'src/presentation/dto/friend/friend-request-list.response';
+import { SearchFriendRequest } from 'src/presentation/dto/friend/search-friend.request';
 import { UserPaginationRequest } from 'src/presentation/dto/user/user-pagination.request';
 
 @UseGuards(AuthGuard)
@@ -73,5 +74,17 @@ export class FriendsController {
       userId,
       paginationDto,
     );
+  }
+
+  @Get('search')
+  async search(
+    @Query() dto: SearchFriendRequest,
+    @CurrentUser() userId: string,
+  ) {
+    const { search, ...paginationInput } = dto;
+    return await this.friendsService.search(userId, {
+      search,
+      paginationInput,
+    });
   }
 }

--- a/src/presentation/dto/friend/friend-list.response.ts
+++ b/src/presentation/dto/friend/friend-list.response.ts
@@ -1,0 +1,6 @@
+import { User } from 'src/domain/types/user.types';
+
+export class FriendListResponse {
+  readonly users: User[];
+  readonly nextCursor: string | null;
+}

--- a/src/presentation/dto/friend/friend-list.response.ts
+++ b/src/presentation/dto/friend/friend-list.response.ts
@@ -1,6 +1,7 @@
 import { User } from 'src/domain/types/user.types';
+import { UserCursor } from 'src/presentation/dto/shared/indexs';
 
 export class FriendListResponse {
   readonly users: User[];
-  readonly nextCursor: string | null;
+  readonly nextCursor: UserCursor | null;
 }

--- a/src/presentation/dto/friend/friend-request-list.response.ts
+++ b/src/presentation/dto/friend/friend-request-list.response.ts
@@ -1,0 +1,7 @@
+import { FriendRequest } from 'src/domain/types/friend.types';
+import { UserCursor } from 'src/presentation/dto/shared/indexs';
+
+export class FriendRequestListResponse {
+  readonly requests: FriendRequest[];
+  readonly nextCursor: UserCursor | null;
+}

--- a/src/presentation/dto/friend/search-friend.request.ts
+++ b/src/presentation/dto/friend/search-friend.request.ts
@@ -1,0 +1,9 @@
+import { Length } from 'class-validator';
+import { UserPaginationRequest } from 'src/presentation/dto/user/user-pagination.request';
+
+export class SearchFriendRequest extends UserPaginationRequest {
+  @Length(2, 20, {
+    message: '검색어는 2자 이상 20자 이하만 가능합니다.',
+  })
+  readonly search: string;
+}

--- a/src/presentation/dto/shared/indexs.ts
+++ b/src/presentation/dto/shared/indexs.ts
@@ -1,0 +1,4 @@
+export class UserCursor {
+  readonly name: string;
+  readonly accountId: string;
+}

--- a/src/presentation/dto/user/search-user.response.ts
+++ b/src/presentation/dto/user/search-user.response.ts
@@ -1,6 +1,7 @@
 import { User } from 'src/domain/types/user.types';
+import { UserCursor } from 'src/presentation/dto/shared/indexs';
 
 export class SearchUserResponse {
   readonly users: User[];
-  readonly nextCursor: string | null;
+  readonly nextCursor: UserCursor | null;
 }

--- a/src/presentation/dto/user/user-pagination.request.ts
+++ b/src/presentation/dto/user/user-pagination.request.ts
@@ -1,11 +1,30 @@
-import { Transform } from 'class-transformer';
-import { IsInt, Length } from 'class-validator';
+import { plainToInstance, Transform, Type } from 'class-transformer';
+import { IsInt, Length, ValidateNested } from 'class-validator';
+
+class UserCursor {
+  @Length(2, 20, { message: '이름은 2자 이상 20자 이하입니다.' })
+  readonly name: string;
+
+  @Length(5, 15, { message: '계정 아이디는 5자 이상 15자 이하입니다.' })
+  readonly accountId: string;
+}
 
 export class UserPaginationRequest {
-  @Length(2, 20, { message: '커서는 2자 이상 20자 이하만 가능합니다.' })
-  cursor: string;
+  @ValidateNested({ message: '커서가 유효하지 않습니다.' })
+  @Type(() => UserCursor)
+  @Transform(({ value }) => {
+    try {
+      const json = JSON.parse(value); // JSON 문자열을 객체로 변환;
+      const instnace = plainToInstance(UserCursor, json);
+      console.log(instnace);
+      return instnace;
+    } catch {
+      throw new Error('Invalid cursor format');
+    }
+  })
+  readonly cursor: UserCursor;
 
   @IsInt({ message: 'limit은 정수만 가능합니다.' })
   @Transform(({ value }) => Number(value), { toClassOnly: true })
-  limit: number;
+  readonly limit: number;
 }

--- a/src/presentation/dto/user/user-pagination.request.ts
+++ b/src/presentation/dto/user/user-pagination.request.ts
@@ -15,9 +15,7 @@ export class UserPaginationRequest {
   @Transform(({ value }) => {
     try {
       const json = JSON.parse(value); // JSON 문자열을 객체로 변환;
-      const instnace = plainToInstance(UserCursor, json);
-      console.log(instnace);
-      return instnace;
+      return plainToInstance(UserCursor, json);
     } catch {
       throw new Error('Invalid cursor format');
     }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,7 +2,10 @@ export type Provider = 'GOOGLE' | 'KAKAO' | 'APPLE';
 
 export type FriendStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'REPORTED';
 
-export interface PaginationInput {
-  cursor: string;
-  limit: number;
+export interface UserPaginationInput {
+  readonly cursor: {
+    readonly name: string;
+    readonly accountId: string;
+  };
+  readonly limit: number;
 }

--- a/test/e2e/friends.e2e-spec.ts
+++ b/test/e2e/friends.e2e-spec.ts
@@ -141,16 +141,19 @@ describe('FriendsController (e2e)', () => {
         },
       });
       const user1 = await prisma.user.create({
-        data: generateUserEntity('test1@test.com', 'lighty_1', '이민수'),
+        data: generateUserEntity('test1@test.com', 'lighty_1', '이민수'), // 4
       });
       const user2 = await prisma.user.create({
-        data: generateUserEntity('test2@test.com', 'lighty_2', 'kkiri'),
+        data: generateUserEntity('test2@test.com', 'lighty_2', '김진수'), // 1
       });
       const user3 = await prisma.user.create({
-        data: generateUserEntity('test3@test.com', 'lighty_3', '김진수'),
+        data: generateUserEntity('test3@test.com', 'lighty_3', '김진수'), // 2
+      });
+      const user4 = await prisma.user.create({
+        data: generateUserEntity('test4@test.com', 'lighty_4', '김진수'), // 3
       });
       const nonFriend = await prisma.user.create({
-        data: generateUserEntity('test4@test.com', 'lighty_4', '박김수'),
+        data: generateUserEntity('test5@test.com', 'lighty_5', '박김수'),
       });
       const friendRealtion1 = await prisma.friend.create({
         data: generateFriendEntity(loginedUser!.id, user1.id),
@@ -161,17 +164,25 @@ describe('FriendsController (e2e)', () => {
       const friendRealtion3 = await prisma.friend.create({
         data: generateFriendEntity(loginedUser!.id, user3.id),
       });
-      const expectedUsers = [user3, user1, user2];
-      const cursor = '가가';
+      const friendRealtion4 = await prisma.friend.create({
+        data: generateFriendEntity(loginedUser!.id, user4.id),
+      });
+      const expectedUsers = [user3, user4, user1];
+      const cursor = {
+        name: user2.name,
+        accountId: user2.accountId,
+      };
       const limit = 3;
 
       // when
+      const url = encodeURI(
+        `/friends?cursor=${JSON.stringify(cursor)}&limit=${limit}`,
+      );
       const response = await request(app.getHttpServer())
-        .get(encodeURI(`/friends?cursor=${cursor}&limit=${limit}`))
+        .get(url)
         .set('Authorization', accessToken);
       const { status, body }: ResponseResult<FriendListResponse> = response;
       console.log(body);
-
       expect(status).toEqual(200);
       expect(body.nextCursor).toEqual(expectedUsers.at(-1)?.name);
       body.users.forEach((user, i) => {

--- a/test/e2e/friends.e2e-spec.ts
+++ b/test/e2e/friends.e2e-spec.ts
@@ -184,7 +184,10 @@ describe('FriendsController (e2e)', () => {
       const { status, body }: ResponseResult<FriendListResponse> = response;
       console.log(body);
       expect(status).toEqual(200);
-      expect(body.nextCursor).toEqual(expectedUsers.at(-1)?.name);
+      expect(body.nextCursor).toEqual({
+        name: expectedUsers.at(-1)?.name,
+        accountId: expectedUsers.at(-1)?.accountId,
+      });
       body.users.forEach((user, i) => {
         expect(user.id).toEqual(expectedUsers[i].id);
         expect(user.accountId).toEqual(expectedUsers[i].accountId);

--- a/test/e2e/friends.e2e-spec.ts
+++ b/test/e2e/friends.e2e-spec.ts
@@ -158,16 +158,16 @@ describe('FriendsController (e2e)', () => {
         data: generateUserEntity('test5@test.com', 'lighty_5', '박김수'),
       });
       const friendRealtion1 = await prisma.friend.create({
-        data: generateFriendEntity(loginedUser!.id, user1.id),
+        data: generateFriendEntity(loginedUser!.id, user1.id, 'ACCEPTED'),
       });
       const friendRealtion2 = await prisma.friend.create({
-        data: generateFriendEntity(user2.id, loginedUser!.id),
+        data: generateFriendEntity(user2.id, loginedUser!.id, 'ACCEPTED'),
       });
       const friendRealtion3 = await prisma.friend.create({
-        data: generateFriendEntity(loginedUser!.id, user3.id),
+        data: generateFriendEntity(loginedUser!.id, user3.id, 'ACCEPTED'),
       });
       const friendRealtion4 = await prisma.friend.create({
-        data: generateFriendEntity(loginedUser!.id, user4.id),
+        data: generateFriendEntity(loginedUser!.id, user4.id, 'ACCEPTED'),
       });
       const expectedUsers = [user3, user4, user1];
       const cursor = {

--- a/test/e2e/users.e2e-spec.ts
+++ b/test/e2e/users.e2e-spec.ts
@@ -33,39 +33,42 @@ describe('UsersController (e2e)', () => {
       const { accessToken } = await login(app);
 
       const user1 = await prisma.user.create({
-        data: generateUserEntity('test1@test.com', 'lighty_1', '김민수'), // 3
+        data: generateUserEntity('test1@test.com', 'lighty_1', '김민수'), // 4
       });
       const user2 = await prisma.user.create({
-        data: generateUserEntity('test2@test.com', 'lighty_2', '김기수'), // 2
+        data: generateUserEntity('test2@test.com', 'lighty_2', '김기수'), // 3
       });
       const user3 = await prisma.user.create({
-        data: generateUserEntity('test3@test.com', 'lighty_3', '박민수'), //4
+        data: generateUserEntity('test3@test.com', 'lighty_3', '박민수'), //5
       });
       const user4 = await prisma.user.create({
         data: generateUserEntity('test4@test.com', 'lighty_4', '강민수'), // 1
       });
       const user5 = await prisma.user.create({
-        data: generateUserEntity('test5@test.com', 'lighty_5', '조민수'), //5
+        data: generateUserEntity('test5@test.com', 'lighty_5', '조민수'), //6
       });
       const user6 = await prisma.user.create({
-        data: generateUserEntity('test6@test.com', 'lighty_6', '조민수'), // 6
+        data: generateUserEntity('test6@test.com', 'lighty_6', '강민수'), // 2
       });
       const nonSearchedUser = await prisma.user.create({
         data: generateUserEntity('test7@test.com', 'righty', '이민수'),
       });
 
       const searchKeyword = 'lig';
-      const cursor = user4.name;
+      const cursor = {
+        name: user4.name, // 강민수
+        accountId: user4.accountId,
+      };
       const limit = 4;
-      const expectedUsers = [user2, user1, user3, user5];
-
+      const expectedUsers = [user6, user2, user1, user3];
+      const url = encodeURI(
+        `/users/search?search=${searchKeyword}&cursor=${JSON.stringify(
+          cursor,
+        )}&limit=${limit}`,
+      );
       // when
       const response = await request(app.getHttpServer())
-        .get(
-          encodeURI(
-            `/users/search?search=${searchKeyword}&cursor=${cursor}&limit=${limit}`,
-          ),
-        )
+        .get(url)
         .set('Authorization', accessToken);
       const { status, body }: ResponseResult<SearchUserResponse> = response;
 

--- a/test/e2e/users.e2e-spec.ts
+++ b/test/e2e/users.e2e-spec.ts
@@ -73,7 +73,10 @@ describe('UsersController (e2e)', () => {
       const { status, body }: ResponseResult<SearchUserResponse> = response;
 
       expect(status).toEqual(200);
-      expect(body.nextCursor).toEqual(expectedUsers.at(-1)?.name);
+      expect(body.nextCursor).toEqual({
+        name: expectedUsers.at(-1)?.name,
+        accountId: expectedUsers.at(-1)?.accountId,
+      });
       body.users.forEach((user, i) => {
         expect(user.id).toEqual(expectedUsers[i].id);
         expect(user.accountId).toEqual(expectedUsers[i].accountId);

--- a/test/helpers/generators.ts
+++ b/test/helpers/generators.ts
@@ -2,6 +2,7 @@ import { v4 } from 'uuid';
 import { UserEntity } from 'src/domain/entities/user/user.entity';
 import { Provider } from 'src/shared/types';
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
+import { FriendStatus } from '@prisma/client';
 
 export const generateUserEntity = (
   email: string,
@@ -19,12 +20,8 @@ export const generateUserEntity = (
 export const generateFriendEntity = (
   senderId: string,
   receiverId: string,
-): FriendEntity =>
-  FriendEntity.create(
-    {
-      senderId,
-      receiverId,
-    },
-    v4,
-    new Date(),
-  );
+  status: FriendStatus = 'PENDING',
+): FriendEntity => {
+  const stdDate = new Date();
+  return new FriendEntity(v4(), senderId, receiverId, stdDate, stdDate, status);
+};


### PR DESCRIPTION
## 작업 내역
- 친구 목록 조회 기능 구현.
- 회원 관련 조회에서 커서의 이름과 동명이인이 조회되지 않던 현상 수정.
  - 커서를 기존 name에서 { name, accountId } 다중 값으로 변경.
  - 이름이 같은 경우 accountId를 기준으로 조회하는 조건 추가.
- 받은, 보낸 친구 요청 목록 조회 기능 구현.
- 친구 검색 기능 구현.
- 정상 동장 e2e 테스트 작성.
