### PR TITLE
회원 정보 수정 기능 구현

### DIFF
--- a/src/domain/entities/user/user.entity.ts
+++ b/src/domain/entities/user/user.entity.ts
@@ -17,6 +17,7 @@ export class UserEntity {
     input: UserPrototype,
     idGen: () => string,
     stdDate: Date,
+    updatedAt?: Date,
   ): UserEntity {
     return new UserEntity(
       idGen(),
@@ -26,7 +27,7 @@ export class UserEntity {
       input.provider,
       input.profileImageUrl,
       stdDate,
-      stdDate,
+      updatedAt ? updatedAt : stdDate,
     );
   }
 }

--- a/src/domain/error/messages/index.ts
+++ b/src/domain/error/messages/index.ts
@@ -11,3 +11,6 @@ export const GROUP_GATHERING_REQUIRED_GROUPID_MESSAGE =
   '그룹 타입의 모임에 그룹 번호는 필수입니다.';
 export const MINIMUM_FRIENDS_REQUIRED_MESSAGE =
   '친구가 최소 1명은 있어야합니다.';
+export const DUPLICATE_ACCOUNT_ID_MESSAGE = '이미 존재하는 계정 아이디입니다.';
+export const ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE =
+  '계정 아이디는 30일에 한 번 변경 가능합니다.';

--- a/src/domain/interface/users.repository.ts
+++ b/src/domain/interface/users.repository.ts
@@ -12,6 +12,7 @@ export interface UsersRepository {
     userId: string,
     searchInput: SearchInput,
   ): Promise<User[]>;
+  update(data: Partial<UserEntity>): Promise<void>;
 }
 
 export const UsersRepository = Symbol('UsersRepository');

--- a/src/domain/interface/users.repository.ts
+++ b/src/domain/interface/users.repository.ts
@@ -7,7 +7,9 @@ export interface UsersRepository {
   findOneByEmail(email: string): Promise<UserBasicInfo | null>;
   // 현재는 존재 유무만 판별하면 돼서 id만 조회.
   findOneByAccountId(accountId: string): Promise<{ id: string } | null>;
-  findOneById(id: string): Promise<{ id: string } | null>;
+  findOneById(
+    id: string,
+  ): Promise<{ id: string; createdAt: Date; updatedAt: Date } | null>;
   findByAccountIdContaining(
     userId: string,
     searchInput: SearchInput,

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -23,4 +23,8 @@ export class UsersService {
       nextCursor,
     };
   }
+
+  async updateProfileImage(userId: string, profileImageUrl: string) {
+    await this.usersRepository.update({ id: userId, profileImageUrl });
+  }
 }

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -40,8 +40,12 @@ export class UsersService {
     await this.usersRepository.update({ id: userId, profileImageUrl });
   }
 
-  async updateAccountId(userId: string, accountId: string) {
-    await this.checkAccountIdChangeCooldown(userId);
+  async updateAccountId(
+    userId: string,
+    accountId: string,
+    today: Date = new Date(),
+  ) {
+    await this.checkAccountIdChangeCooldown(userId, today);
     await this.checkDuplicateAccountId(accountId);
 
     await this.usersRepository.update({ id: userId, accountId });
@@ -65,10 +69,7 @@ export class UsersService {
     }
   }
 
-  private async checkAccountIdChangeCooldown(
-    userId: string,
-    today: Date = new Date(),
-  ) {
+  private async checkAccountIdChangeCooldown(userId: string, today: Date) {
     const { createdAt, updatedAt } = await this.getUserByIdOrThrow(userId);
 
     if (

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -1,7 +1,19 @@
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import {
+  ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE,
+  DUPLICATE_ACCOUNT_ID_MESSAGE,
+  NOT_FOUND_USER_MESSAGE,
+} from 'src/domain/error/messages';
 import { UsersRepository } from 'src/domain/interface/users.repository';
 import { getUserCursor } from 'src/domain/shared/get-cursor';
 import { SearchInput } from 'src/domain/types/user.types';
+import { calcDateDiff, convertUnixToDate } from 'src/utils/date';
 
 @Injectable()
 export class UsersService {
@@ -26,5 +38,46 @@ export class UsersService {
 
   async updateProfileImage(userId: string, profileImageUrl: string) {
     await this.usersRepository.update({ id: userId, profileImageUrl });
+  }
+
+  async updateAccountId(userId: string, accountId: string) {
+    await this.checkAccountIdChangeCooldown(userId);
+    await this.checkDuplicateAccountId(accountId);
+
+    await this.usersRepository.update({ id: userId, accountId });
+  }
+
+  private async getUserByIdOrThrow(userId: string) {
+    const user = await this.usersRepository.findOneById(userId);
+    if (!user) {
+      throw new NotFoundException(NOT_FOUND_USER_MESSAGE(userId));
+    }
+
+    return user;
+  }
+
+  private async checkDuplicateAccountId(accountId: string) {
+    const userByAccountId = await this.usersRepository.findOneByAccountId(
+      accountId,
+    );
+    if (userByAccountId) {
+      throw new ConflictException(DUPLICATE_ACCOUNT_ID_MESSAGE);
+    }
+  }
+
+  private async checkAccountIdChangeCooldown(
+    userId: string,
+    today: Date = new Date(),
+  ) {
+    const { createdAt, updatedAt } = await this.getUserByIdOrThrow(userId);
+
+    if (
+      createdAt.getTime() !== updatedAt.getTime() &&
+      convertUnixToDate(calcDateDiff(today, updatedAt)) < 30
+    ) {
+      throw new UnprocessableEntityException(
+        ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE,
+      );
+    }
   }
 }

--- a/src/domain/types/friend.types.ts
+++ b/src/domain/types/friend.types.ts
@@ -1,3 +1,5 @@
+import { User } from 'src/domain/types/user.types';
+
 export interface FriendPrototype {
   readonly senderId: string;
   readonly receiverId: string;
@@ -6,11 +8,4 @@ export interface FriendPrototype {
 export interface FriendRequest {
   readonly id: string;
   readonly sender: User;
-}
-
-interface User {
-  readonly id: string;
-  readonly accountId: string;
-  readonly name: string;
-  readonly profileImageUrl: string;
 }

--- a/src/domain/types/user.types.ts
+++ b/src/domain/types/user.types.ts
@@ -18,7 +18,7 @@ export interface User {
   readonly id: string;
   readonly accountId: string;
   readonly name: string;
-  readonly profileImageUrl: string;
+  readonly profileImageUrl: string | null;
 }
 
 export interface SearchInput {

--- a/src/infrastructure/repositories/users-prisma.repository.ts
+++ b/src/infrastructure/repositories/users-prisma.repository.ts
@@ -92,4 +92,16 @@ export class UsersPrismaRepository implements UsersRepository {
       profileImageUrl: row.profile_image_url,
     }));
   }
+
+  async update(data: Partial<UserEntity>): Promise<void> {
+    const { id, profileImageUrl } = data;
+    await this.prisma.user.update({
+      data: {
+        profileImageUrl,
+      },
+      where: {
+        id,
+      },
+    });
+  }
 }

--- a/src/infrastructure/repositories/users-prisma.repository.ts
+++ b/src/infrastructure/repositories/users-prisma.repository.ts
@@ -37,10 +37,14 @@ export class UsersPrismaRepository implements UsersRepository {
     });
   }
 
-  async findOneById(id: string): Promise<{ id: string } | null> {
+  async findOneById(
+    id: string,
+  ): Promise<{ id: string; createdAt: Date; updatedAt: Date } | null> {
     return await this.prisma.user.findUnique({
       select: {
         id: true,
+        createdAt: true,
+        updatedAt: true,
       },
       where: {
         id,
@@ -94,11 +98,9 @@ export class UsersPrismaRepository implements UsersRepository {
   }
 
   async update(data: Partial<UserEntity>): Promise<void> {
-    const { id, profileImageUrl } = data;
+    const { id, ...updateDate } = data;
     await this.prisma.user.update({
-      data: {
-        profileImageUrl,
-      },
+      data: updateDate,
       where: {
         id,
       },

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -30,6 +30,7 @@ import { SearchUserResponse } from 'src/presentation/dto/user/response/search-us
 import { UploadImageResponse } from 'src/presentation/dto/file/response/upload-image.response';
 import { IMAGE_BASE_URL } from 'src/common/constant';
 import { ChangeProfileImageRequest } from 'src/presentation/dto/user/request/change-profile-image.request';
+import { ChangeAccountIdRequest } from 'src/presentation/dto';
 
 @ApiTags('/users')
 @ApiBearerAuth()
@@ -100,5 +101,35 @@ export class UsersController {
     @CurrentUser() userId: string,
   ) {
     await this.usersService.updateProfileImage(userId, dto.profileImageUrl);
+  }
+
+  @ApiOperation({ summary: '계정 아이디 변경' })
+  @ApiResponse({
+    status: 204,
+    description: '변경 성공',
+  })
+  @ApiResponse({
+    status: 409,
+    description: '이미 존재하는 계정 아이디',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '존재하지 않는 회원 번호',
+  })
+  @ApiResponse({
+    status: 422,
+    description: '마지막 변경일로부터 30일 미경과',
+  })
+  @ApiResponse({
+    status: 400,
+    description: '입력값 검증 실패',
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Patch('account-id')
+  async changeAccountId(
+    @Body() dto: ChangeAccountIdRequest,
+    @CurrentUser() userId: string,
+  ) {
+    await this.usersService.updateAccountId(userId, dto.accountId);
   }
 }

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -1,7 +1,10 @@
 import {
+  Body,
   Controller,
   Get,
   HttpCode,
+  HttpStatus,
+  Patch,
   Post,
   Query,
   UploadedFile,
@@ -26,6 +29,7 @@ import { SearchUserRequest } from 'src/presentation/dto/user/request/search-user
 import { SearchUserResponse } from 'src/presentation/dto/user/response/search-user.response';
 import { UploadImageResponse } from 'src/presentation/dto/file/response/upload-image.response';
 import { IMAGE_BASE_URL } from 'src/common/constant';
+import { ChangeProfileImageRequest } from 'src/presentation/dto/user/request/change-profile-image.request';
 
 @ApiTags('/users')
 @ApiBearerAuth()
@@ -34,7 +38,7 @@ import { IMAGE_BASE_URL } from 'src/common/constant';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @ApiOperation({ summary: '프로필 이미지 업로드' })
+  @ApiOperation({ summary: '프로필 사진 업로드' })
   @ApiBody({ type: FileRequest })
   @ApiResponse({
     status: 200,
@@ -78,5 +82,23 @@ export class UsersController {
   ): Promise<SearchUserResponse> {
     const { search, ...paginationInput } = dto;
     return await this.usersService.search(userId, { search, paginationInput });
+  }
+
+  @ApiOperation({ summary: '프로필 사진 변경' })
+  @ApiResponse({
+    status: 204,
+    description: '변경 성공',
+  })
+  @ApiResponse({
+    status: 400,
+    description: '입력값 검증 실패',
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Patch('profile/image')
+  async changeProfileImage(
+    @Body() dto: ChangeProfileImageRequest,
+    @CurrentUser() userId: string,
+  ) {
+    await this.usersService.updateProfileImage(userId, dto.profileImageUrl);
   }
 }

--- a/src/presentation/dto/user/index.ts
+++ b/src/presentation/dto/user/index.ts
@@ -1,5 +1,7 @@
 export * from './request/search-user.request';
 export * from './request/user-pagination.request';
+export * from './request/change-profile-image.request';
+export * from './request/change-account-id.request';
 export * from './response/login-fail.response';
 export * from './response/search-user.response';
 export * from './response/data.types';

--- a/src/presentation/dto/user/request/change-account-id.request.ts
+++ b/src/presentation/dto/user/request/change-account-id.request.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Length } from 'class-validator';
+
+export class ChangeAccountIdRequest {
+  @ApiProperty()
+  @Length(5, 15, { message: '계정 아이디는 최소 5자 최대 15자만 가능합니다.' })
+  readonly accountId: string;
+}

--- a/src/presentation/dto/user/request/change-profile-image.request.ts
+++ b/src/presentation/dto/user/request/change-profile-image.request.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUrl } from 'class-validator';
+
+export class ChangeProfileImageRequest {
+  @ApiProperty()
+  @IsUrl({}, { message: 'url 형식이 아닙니다.' })
+  readonly profileImageUrl: string;
+}

--- a/src/presentation/dto/user/response/data.types.ts
+++ b/src/presentation/dto/user/response/data.types.ts
@@ -11,5 +11,5 @@ export class User {
   readonly name: string;
 
   @ApiProperty()
-  readonly profileImageUrl: string;
+  readonly profileImageUrl: string | null;
 }

--- a/src/utils/date/index.ts
+++ b/src/utils/date/index.ts
@@ -1,0 +1,8 @@
+export const calcDateDiff = (firstDate: Date, secondDate: Date) => {
+  return Math.abs(firstDate.getTime() - secondDate.getTime());
+};
+
+export const convertUnixToDate = (time: number) => {
+  const date = Math.floor(time / (1000 * 60 * 60 * 24));
+  return date;
+};

--- a/test/e2e/groups.e2e-spec.ts
+++ b/test/e2e/groups.e2e-spec.ts
@@ -209,7 +209,6 @@ describe('GroupsController (e2e)', () => {
         .set('Authorization', accessToken);
       const { status, body }: ResponseResult<GroupListResponse> = response;
       const { groups, nextCursor } = body;
-      console.log(groups);
 
       expect(status).toEqual(200);
       expect(nextCursor).toEqual(groupParticipationStdDate3.toISOString());

--- a/test/helpers/generators.ts
+++ b/test/helpers/generators.ts
@@ -12,11 +12,14 @@ export const generateUserEntity = (
   name = '이름',
   profileImageUrl = 'https://image.com',
   provider: Provider = 'GOOGLE',
+  stdDate: Date = new Date(),
+  updatedAt?: Date,
 ): UserEntity =>
   UserEntity.create(
     { accountId, email, name, profileImageUrl, provider },
     v4,
-    new Date(),
+    stdDate,
+    updatedAt ? updatedAt : undefined,
   );
 
 export const generateFriendEntity = (

--- a/test/unit/jest.json
+++ b/test/unit/jest.json
@@ -2,11 +2,12 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "../../",
   "testEnvironment": "node",
-  "testRegex": "spec.ts$",
+  "testRegex": ".unit-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
   "moduleNameMapper": {
-    "^src/(.*)$": "<rootDir>/src/$1"
+    "^src/(.*)$": "<rootDir>/src/$1",
+    "^test/(.*)$": "<rootDir>/test/$1"
   }
 }

--- a/test/unit/users.service.unit-spec.ts
+++ b/test/unit/users.service.unit-spec.ts
@@ -1,0 +1,80 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClsModule } from 'nestjs-cls';
+import { clsOptions } from 'src/configs/cls/cls-options';
+import { ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE } from 'src/domain/error/messages';
+import { UsersRepository } from 'src/domain/interface/users.repository';
+import { UsersService } from 'src/domain/services/user/users.service';
+import { PrismaModule } from 'src/infrastructure/prisma/prisma.module';
+import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
+import { UsersPrismaRepository } from 'src/infrastructure/repositories/users-prisma.repository';
+import { generateUserEntity } from 'test/helpers/generators';
+
+describe('UsersService', () => {
+  let usersService: UsersService;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      imports: [ClsModule.forRoot(clsOptions), PrismaModule],
+      providers: [
+        UsersService,
+        { provide: UsersRepository, useClass: UsersPrismaRepository },
+      ],
+    }).compile();
+
+    usersService = app.get<UsersService>(UsersService);
+    prisma = app.get<PrismaService>(PrismaService);
+  });
+
+  afterEach(async () => {
+    await prisma.user.deleteMany();
+  });
+
+  it('마지막 계정 아이디 변경 후 30일이 지나지 않은 경우 예외', async () => {
+    const user = await prisma.user.create({
+      data: generateUserEntity(
+        'test@test.com',
+        'lighty',
+        '이름',
+        'http://image.com',
+        'GOOGLE',
+        new Date('2024-01-01T00:00:00.000Z'),
+        new Date('2024-01-02T00:00:01.000Z'),
+      ),
+    });
+    const { id } = user;
+    const newAccountId = 'new_lighty';
+    const today = new Date('2024-02-01T00:00:00.000Z');
+
+    await expect(
+      async () => await usersService.updateAccountId(id, newAccountId, today),
+    ).rejects.toThrow(
+      new UnprocessableEntityException(ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE),
+    );
+  });
+
+  it('마지막 계정 아이디 변경 후 30일 경과 후 정상 동작', async () => {
+    const user = await prisma.user.create({
+      data: generateUserEntity(
+        'test@test.com',
+        'lighty',
+        '이름',
+        'http://image.com',
+        'GOOGLE',
+        new Date('2024-01-01T00:00:00.000Z'),
+        new Date('2024-01-02T00:00:01.000Z'),
+      ),
+    });
+    const { id } = user;
+    const newAccountId = 'new_lighty';
+    const today = new Date('2024-02-02T00:00:00.000Z');
+
+    await usersService.updateAccountId(id, newAccountId, today);
+    const updatedUser = await prisma.user.findUnique({
+      where: { id },
+    });
+
+    expect(updatedUser?.accountId).toEqual(newAccountId);
+  });
+});


### PR DESCRIPTION
## 연관 이슈
- #50 

## 작업 내용
- 회원 생성 시 profileImageUrl 옵셔널로 변경.
- 프로필 사진 변경 기능 구현.
- 계정 아이디 변경 기능 구현.
  - 정상 동작 e2e
  - 이미 존재하는 계정 아이디 예외 e2e
  - 계정 아이디 변경 후 30일 경과 전 변경하려는 경우 예외 unit
  - 30일 경과 후 정상 동작 unit