### PR TITLE
친구 데이터 중복 생성 가능한 현상 제거

### DIFF
--- a/prisma/generated/types.ts
+++ b/prisma/generated/types.ts
@@ -18,7 +18,6 @@ export type GatheringType = (typeof GatheringType)[keyof typeof GatheringType];
 export const FriendStatus = {
   PENDING: 'PENDING',
   ACCEPTED: 'ACCEPTED',
-  REJECTED: 'REJECTED',
   REPORTED: 'REPORTED',
 } as const;
 export type FriendStatus = (typeof FriendStatus)[keyof typeof FriendStatus];

--- a/prisma/migrations/20250114102458_remove_rejected_status_to_friend_status/migration.sql
+++ b/prisma/migrations/20250114102458_remove_rejected_status_to_friend_status/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The values [REJECTED] on the enum `FriendStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "FriendStatus_new" AS ENUM ('PENDING', 'ACCEPTED', 'REPORTED');
+ALTER TABLE "friend" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "friend" ALTER COLUMN "status" TYPE "FriendStatus_new" USING ("status"::text::"FriendStatus_new");
+ALTER TYPE "FriendStatus" RENAME TO "FriendStatus_old";
+ALTER TYPE "FriendStatus_new" RENAME TO "FriendStatus";
+DROP TYPE "FriendStatus_old";
+ALTER TABLE "friend" ALTER COLUMN "status" SET DEFAULT 'PENDING';
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,6 @@ enum GatheringType {
 enum FriendStatus {
   PENDING
   ACCEPTED
-  REJECTED
   REPORTED
 }
 

--- a/src/domain/error/messages/index.ts
+++ b/src/domain/error/messages/index.ts
@@ -3,6 +3,9 @@ export const NOT_FOUND_USER_MESSAGE = (info: string) =>
 export const NOT_FOUND_FRIEND_MESSAGE = '존재하지 않는 친구 혹은 요청입니다.';
 export const NOT_FOUND_GATHERING_MESSAGE = '존재하지 않는 모임입니다.';
 export const FRIEND_REQUEST_ALREADY_EXIST_MESSAGE = `이미 존재하는 요청입니다.`;
+export const FRIEND_ALREADY_EXIST_MESSAGE = '이미 친구인 회원입니다.';
+export const CANT_REQUEST_REPORTED_FRIEND_MESSAGE =
+  '신고한 회원에게 친구 요청을 보낼 수 없습니다.';
 export const FORBIDDEN_MESSAGE = '권한이 없습니다.';
 export const IS_NOT_FRIEND_RELATION_MESSAGE = '친구 관계가 아닙니다.';
 export const GROUP_OWNER_CANT_LEAVE_MESSAGE =

--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -2,7 +2,7 @@ import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FriendRequest } from 'src/domain/types/friend.types';
 import { User } from 'src/domain/types/user.types';
 import { SearchInput } from 'src/infrastructure/types/user.types';
-import { UserPaginationInput } from 'src/shared/types';
+import { FriendStatus, UserPaginationInput } from 'src/shared/types';
 
 export interface FriendsRepository {
   save(data: FriendEntity): Promise<void>;
@@ -26,7 +26,7 @@ export interface FriendsRepository {
   findOneBySenderAndReceiverId(
     firstUserId: string,
     secondUserId: string,
-  ): Promise<{ id: string } | null>;
+  ): Promise<{ id: string; status: FriendStatus } | null>;
   update(id: string, data: Partial<FriendEntity>): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -117,6 +117,7 @@ export class FriendsService {
       if (existFriend.status === 'PENDING') {
         throw new ConflictException(FRIEND_REQUEST_ALREADY_EXIST_MESSAGE);
       }
+      // TODO 요구사항 변경에 따라 수정 가능성 있음.
       if (existFriend.status === 'REPORTED') {
         throw new BadRequestException(CANT_REQUEST_REPORTED_FRIEND_MESSAGE);
       }

--- a/src/domain/services/gathering/gatherings-write.service.ts
+++ b/src/domain/services/gathering/gatherings-write.service.ts
@@ -104,7 +104,7 @@ export class GatheringsWriteService {
         friendId,
         userId,
       );
-      if (!friend) {
+      if (!friend || friend.status !== 'ACCEPTED') {
         throw new BadRequestException(IS_NOT_FRIEND_RELATION_MESSAGE);
       }
     });

--- a/src/domain/services/group/group-create.service.ts
+++ b/src/domain/services/group/group-create.service.ts
@@ -77,7 +77,7 @@ export class GroupCreateService {
       friendId,
       userId,
     );
-    if (!friend) {
+    if (!friend || friend.status !== 'ACCEPTED') {
       throw new BadRequestException(IS_NOT_FRIEND_RELATION_MESSAGE);
     }
   }

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -15,19 +15,9 @@ export class FriendsPrismaRepository implements FriendsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async save(data: FriendEntity): Promise<void> {
-    try {
-      await this.prisma.friend.create({
-        data,
-      });
-    } catch (e: unknown) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError) {
-        if (e.code === 'P2002') {
-          throw new ConflictException(FRIEND_REQUEST_ALREADY_EXIST_MESSAGE);
-        }
-        throw e;
-      }
-      throw e;
-    }
+    await this.prisma.friend.create({
+      data,
+    });
   }
 
   async findOneById(

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -1,5 +1,5 @@
 import { ConflictException, Injectable } from '@nestjs/common';
-import { FriendStatus, Prisma } from '@prisma/client';
+import { FriendStatus as PrismaFriendStatus, Prisma } from '@prisma/client';
 import { sql } from 'kysely';
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { FRIEND_REQUEST_ALREADY_EXIST_MESSAGE } from 'src/domain/error/messages';
@@ -8,7 +8,7 @@ import { FriendRequest } from 'src/domain/types/friend.types';
 import { User } from 'src/domain/types/user.types';
 import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
 import { SearchInput } from 'src/infrastructure/types/user.types';
-import { UserPaginationInput } from 'src/shared/types';
+import { FriendStatus, UserPaginationInput } from 'src/shared/types';
 
 @Injectable()
 export class FriendsPrismaRepository implements FriendsRepository {
@@ -70,7 +70,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
           .where(
             'f.status',
             '=',
-            sql<FriendStatus>`${FriendStatus.ACCEPTED}::"FriendStatus"`,
+            sql<PrismaFriendStatus>`${PrismaFriendStatus.ACCEPTED}::"FriendStatus"`,
           )
           .union((qb) =>
             qb
@@ -80,7 +80,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
               .where(
                 'f.status',
                 '=',
-                sql<FriendStatus>`${FriendStatus.ACCEPTED}::"FriendStatus"`,
+                sql<PrismaFriendStatus>`${PrismaFriendStatus.ACCEPTED}::"FriendStatus"`,
               ),
           ),
       )
@@ -124,7 +124,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
           .where(
             'f.status',
             '=',
-            sql<FriendStatus>`${FriendStatus.ACCEPTED}::"FriendStatus"`,
+            sql<PrismaFriendStatus>`${PrismaFriendStatus.ACCEPTED}::"FriendStatus"`,
           )
           .union((qb) =>
             qb
@@ -134,7 +134,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
               .where(
                 'f.status',
                 '=',
-                sql<FriendStatus>`${FriendStatus.ACCEPTED}::"FriendStatus"`,
+                sql<PrismaFriendStatus>`${PrismaFriendStatus.ACCEPTED}::"FriendStatus"`,
               ),
           ),
       )
@@ -176,7 +176,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
       .where(
         'f.status',
         '=',
-        sql<FriendStatus>`${FriendStatus.PENDING}::"FriendStatus"`,
+        sql<PrismaFriendStatus>`${PrismaFriendStatus.PENDING}::"FriendStatus"`,
       )
       .where(({ eb, or, and }) =>
         or([
@@ -222,7 +222,7 @@ export class FriendsPrismaRepository implements FriendsRepository {
       .where(
         'f.status',
         '=',
-        sql<FriendStatus>`${FriendStatus.PENDING}::"FriendStatus"`,
+        sql<PrismaFriendStatus>`${PrismaFriendStatus.PENDING}::"FriendStatus"`,
       )
       .where(({ eb, or, and }) =>
         or([
@@ -252,9 +252,9 @@ export class FriendsPrismaRepository implements FriendsRepository {
   async findOneBySenderAndReceiverId(
     firstUserId: string,
     secondUserId: string,
-  ): Promise<{ id: string } | null> {
+  ): Promise<{ id: string; status: FriendStatus } | null> {
     return await this.prisma.friend.findFirst({
-      select: { id: true },
+      select: { id: true, status: true },
       where: {
         status: 'ACCEPTED',
         OR: [

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -246,7 +246,6 @@ export class FriendsPrismaRepository implements FriendsRepository {
     return await this.prisma.friend.findFirst({
       select: { id: true, status: true },
       where: {
-        status: 'ACCEPTED',
         OR: [
           {
             AND: [{ senderId: firstUserId }, { receiverId: secondUserId }],

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,6 +1,6 @@
 export type Provider = 'GOOGLE' | 'KAKAO' | 'APPLE';
 
-export type FriendStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'REPORTED';
+export type FriendStatus = 'PENDING' | 'ACCEPTED' | 'REPORTED';
 
 export type GatheringType = 'GROUP' | 'FRIEND';
 


### PR DESCRIPTION
## 연관 이슈
- #56 

## 원인
- senderId, receiverId를 한 쌍으로 순서에 상관 없이 중복 데이터가 생성되면 안 되지만, [senderId, receiverId] 순으로 unique 제약조건을 걸어서, 두 값의 순서가 반대가 되는 경우에는 정상적으로 삽입이 되었음.

## 해결
- service 단에서 중복 예외처리 추가.

## 작업 내용
- 친구 데이터 중복 예외처리 추가.
- 이미 친구인 회원에게 친구 요청하는 경우 예외 테스트 작성 e2e.
- 자신에게 요청을 보낸 친구에게 요청하는 경우 예외 테스트 작성 e2e.
- 자신이 신고한 회원에게 요청하는 경우 예외 테스트 작성 e2e.