### PR TITLE
친구 삭제 시 두 회원 간의 수락 되지 않은 모임 초대도 함께 제거

### DIFF
--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -27,12 +27,16 @@ export interface FriendsRepository {
     firstUserId: string,
     secondUserId: string,
   ): Promise<{ id: string; status: FriendStatus } | null>;
-  findOneFriendByUserId(senderOrReceiverId: string): Promise<{
+  findOneFriendByUserId(
+    firstUserId: string,
+    secondUserId: string,
+  ): Promise<{
     senderId: string;
     receiverId: string;
   } | null>;
   update(id: string, data: Partial<FriendEntity>): Promise<void>;
   delete(id: string): Promise<void>;
+  deleteByUserIds(firstUserId: string, secondUserId: string): Promise<void>;
 }
 
 export const FriendsRepository = Symbol('FriendsRepository');

--- a/src/domain/interface/gathering/gathering-participations.repository.ts
+++ b/src/domain/interface/gathering/gathering-participations.repository.ts
@@ -24,6 +24,15 @@ export interface GatheringParticipationsRepository {
     status: GatheringParticipationStatus,
   ): Promise<void>;
   delete(invitationId: string): Promise<void>;
+  /**
+   * 초대장 송신자와 수신자 순서 상관 없이 입력.
+   * @param firstUserId
+   * @param secondUserId
+   */
+  deleteAllPendingInvitation(
+    firstUserId: string,
+    secondUserId: string,
+  ): Promise<void>;
 }
 
 export const GatheringParticipationsRepository = Symbol(

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -285,4 +285,22 @@ export class FriendsPrismaRepository implements FriendsRepository {
       },
     });
   }
+
+  async deleteByUserIds(
+    firstUserId: string,
+    secondUserId: string,
+  ): Promise<void> {
+    await this.prisma.friend.deleteMany({
+      where: {
+        OR: [
+          {
+            AND: [{ senderId: firstUserId }, { receiverId: secondUserId }],
+          },
+          {
+            AND: [{ senderId: secondUserId }, { receiverId: firstUserId }],
+          },
+        ],
+      },
+    });
+  }
 }

--- a/src/infrastructure/repositories/gathering/gathering-participations-prisma.repository.ts
+++ b/src/infrastructure/repositories/gathering/gathering-participations-prisma.repository.ts
@@ -210,4 +210,29 @@ export class GatheringParticipationsPrismaRepository
       },
     });
   }
+
+  async deleteAllPendingInvitation(
+    firstUserId: string,
+    secondUserId: string,
+  ): Promise<void> {
+    await this.txHost.tx.gatheringParticipation.deleteMany({
+      where: {
+        OR: [
+          {
+            participantId: firstUserId,
+            gathering: {
+              hostUserId: secondUserId,
+            },
+          },
+          {
+            participantId: secondUserId,
+            gathering: {
+              hostUserId: firstUserId,
+            },
+          },
+        ],
+        status: GatheringParticipationStatus.PENDING,
+      },
+    });
+  }
 }

--- a/src/modules/friend/friends.module.ts
+++ b/src/modules/friend/friends.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { FriendsRepository } from 'src/domain/interface/friend/friends.repository';
 import { FriendsService } from 'src/domain/services/friend/friends.service';
 import { FriendsPrismaRepository } from 'src/infrastructure/repositories/friend/friends.prisma.repository';
+import { GatheringParticipationModules } from 'src/modules/gathering/gathering-participation.module';
 import { UsersModule } from 'src/modules/user/users.module';
 import { FriendsController } from 'src/presentation/controllers/friend/friends.controller';
 
 @Module({
-  imports: [UsersModule],
+  imports: [UsersModule, GatheringParticipationModules],
   controllers: [FriendsController],
   providers: [
     FriendsService,

--- a/src/modules/gathering/gathering-participation.module.ts
+++ b/src/modules/gathering/gathering-participation.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { GatheringParticipationsRepository } from 'src/domain/interface/gathering/gathering-participations.repository';
+import { GatheringParticipationsPrismaRepository } from 'src/infrastructure/repositories/gathering/gathering-participations-prisma.repository';
+
+@Module({
+  providers: [
+    {
+      provide: GatheringParticipationsRepository,
+      useClass: GatheringParticipationsPrismaRepository,
+    },
+  ],
+  exports: [
+    {
+      provide: GatheringParticipationsRepository,
+      useClass: GatheringParticipationsPrismaRepository,
+    },
+  ],
+})
+export class GatheringParticipationModules {}

--- a/src/modules/gathering/gatherings.module.ts
+++ b/src/modules/gathering/gatherings.module.ts
@@ -1,27 +1,22 @@
 import { Module } from '@nestjs/common';
-import { GatheringParticipationsRepository } from 'src/domain/interface/gathering/gathering-participations.repository';
 import { GatheringsRepository } from 'src/domain/interface/gathering/gatherings.repository';
 import { GatheringInvitationsReadService } from 'src/domain/services/gathering/gathering-invitations-read.service';
 import { GatheringsReadService } from 'src/domain/services/gathering/gatherings-read.service';
 import { GatheringsWriteService } from 'src/domain/services/gathering/gatherings-write.service';
-import { GatheringParticipationsPrismaRepository } from 'src/infrastructure/repositories/gathering/gathering-participations-prisma.repository';
 import { GatheringsPrismaRepository } from 'src/infrastructure/repositories/gathering/gatherings-prisma.repository';
 import { FriendsModule } from 'src/modules/friend/friends.module';
+import { GatheringParticipationModules } from 'src/modules/gathering/gathering-participation.module';
 import { GroupsModule } from 'src/modules/group/groups.module';
 import { GatheringsController } from 'src/presentation/controllers/gathering/gatherings.controller';
 
 @Module({
-  imports: [FriendsModule, GroupsModule],
+  imports: [FriendsModule, GroupsModule, GatheringParticipationModules],
   controllers: [GatheringsController],
   providers: [
     GatheringsWriteService,
     GatheringsReadService,
     GatheringInvitationsReadService,
     { provide: GatheringsRepository, useClass: GatheringsPrismaRepository },
-    {
-      provide: GatheringParticipationsRepository,
-      useClass: GatheringParticipationsPrismaRepository,
-    },
   ],
   exports: [
     { provide: GatheringsRepository, useClass: GatheringsPrismaRepository },

--- a/src/presentation/controllers/friend/friends.controller.ts
+++ b/src/presentation/controllers/friend/friends.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseUUIDPipe,
   Post,
   Query,
   UseGuards,
@@ -195,6 +196,11 @@ export class FriendsController {
   }
 
   @ApiOperation({ summary: '절교' })
+  @ApiQuery({
+    name: 'userId',
+    description:
+      '친구 관계를 끊을 회원의 번호. 회원 번호!! 친구 번호 말고 회원 번호',
+  })
   @ApiResponse({
     status: 204,
     description: '절교 성공!',
@@ -204,11 +210,11 @@ export class FriendsController {
     description: '친구가 아닌 경우 실패',
   })
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Delete(':friendId')
+  @Delete()
   async delete(
-    @Param('friendId') friendId: string,
+    @Query('userId', ParseUUIDPipe) friendUserId: string,
     @CurrentUser() userId: string,
   ) {
-    await this.friendsService.delete(friendId, userId);
+    await this.friendsService.delete(friendUserId, userId);
   }
 }


### PR DESCRIPTION
## 연관 이슈
- #78 

## 작업 내용
- gathering participation repo를 gathering module에서 export하고 friend module에 주입하면 friend module의 순환 의존이 발생하여 gathering participation module을 따로 분리하고 두 모듈에 따로 주입함.
- 친구 삭제 시 두 회원 간의 수락되지 않은 모임 초대장 모두 제거.
- 친구 삭제 시 초대장 제거를 확인하는 e2e 테스트 작성
- 친구 삭제 api의 잘못 설정된 id 값 변경,
  - 기존: path param의 friendId
  - 변경 후: query param의 userId