### PR TITLE
피드 숨김 기능 구현

### DIFF
--- a/prisma/generated/types.ts
+++ b/prisma/generated/types.ts
@@ -39,8 +39,8 @@ export const NotificationTypes = {
 export type NotificationTypes =
   (typeof NotificationTypes)[keyof typeof NotificationTypes];
 export type BlockedFeed = {
-  userId: string;
-  feedId: string;
+  user_id: string;
+  feed_id: string;
   created_at: Timestamp;
 };
 export type Feed = {

--- a/prisma/migrations/20250122111549_change_to_snake_case/migration.sql
+++ b/prisma/migrations/20250122111549_change_to_snake_case/migration.sql
@@ -1,0 +1,33 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `feedId` on the `blocked_feed` table. All the data in the column will be lost.
+  - You are about to drop the column `userId` on the `blocked_feed` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[user_id,feed_id]` on the table `blocked_feed` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `feed_id` to the `blocked_feed` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `user_id` to the `blocked_feed` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "blocked_feed" DROP CONSTRAINT "blocked_feed_feedId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "blocked_feed" DROP CONSTRAINT "blocked_feed_userId_fkey";
+
+-- DropIndex
+DROP INDEX "blocked_feed_userId_feedId_key";
+
+-- AlterTable
+ALTER TABLE "blocked_feed" DROP COLUMN "feedId",
+DROP COLUMN "userId",
+ADD COLUMN     "feed_id" TEXT NOT NULL,
+ADD COLUMN     "user_id" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "blocked_feed_user_id_feed_id_key" ON "blocked_feed"("user_id", "feed_id");
+
+-- AddForeignKey
+ALTER TABLE "blocked_feed" ADD CONSTRAINT "blocked_feed_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "blocked_feed" ADD CONSTRAINT "blocked_feed_feed_id_fkey" FOREIGN KEY ("feed_id") REFERENCES "feed"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -172,8 +172,8 @@ model FriendFeedVisibility {
 }
 
 model BlockedFeed {
-  userId    String
-  feedId    String
+  userId    String @map("user_id")
+  feedId    String @map("feed_id")
   createdAt DateTime @map("created_at")
 
   user User @relation(fields: [userId], references: [id])

--- a/src/domain/entities/feed/blocked-feed.entity.ts
+++ b/src/domain/entities/feed/blocked-feed.entity.ts
@@ -1,0 +1,17 @@
+export class BlockedFeedEntity {
+  constructor(
+    readonly userId: string,
+    readonly feedId: string,
+    readonly createdAt: Date,
+  ) {}
+
+  static create(
+    proto: { userId: string; feedId: string },
+    stdDate: Date,
+  ): BlockedFeedEntity {
+    return {
+      ...proto,
+      createdAt: stdDate,
+    };
+  }
+}

--- a/src/domain/interface/feed/blocked-feeds.repository.ts
+++ b/src/domain/interface/feed/blocked-feeds.repository.ts
@@ -2,6 +2,7 @@ import { BlockedFeedEntity } from 'src/domain/entities/feed/blocked-feed.entity'
 
 export interface BlockedFeedsRepository {
   save(data: BlockedFeedEntity): Promise<void>;
+  delete(userId: string, feedId: string): Promise<void>;
 }
 
 export const BlockedFeedsRepository = Symbol('BlockedFeedRepository');

--- a/src/domain/interface/feed/blocked-feeds.repository.ts
+++ b/src/domain/interface/feed/blocked-feeds.repository.ts
@@ -1,0 +1,7 @@
+import { BlockedFeedEntity } from 'src/domain/entities/feed/blocked-feed.entity';
+
+export interface BlockedFeedsRepository {
+  save(data: BlockedFeedEntity): Promise<void>;
+}
+
+export const BlockedFeedsRepository = Symbol('BlockedFeedRepository');

--- a/src/domain/interface/feed/feeds.repository.ts
+++ b/src/domain/interface/feed/feeds.repository.ts
@@ -1,6 +1,7 @@
 import { FeedImageEntity } from 'src/domain/entities/feed/feed-image.entity';
 import { FeedEntity } from 'src/domain/entities/feed/feed.entity';
 import { Feed, FeedPaginationInput } from 'src/domain/types/feed.types';
+import { DateIdPaginationInput } from 'src/shared/types';
 
 export interface FeedsRepository {
   save(data: FeedEntity, images: FeedImageEntity[]): Promise<void>;
@@ -21,6 +22,10 @@ export interface FeedsRepository {
   findByUserId(
     userId: string,
     feedPaginationInput: FeedPaginationInput,
+  ): Promise<Feed[]>;
+  findBlockedFeedsByUserId(
+    userId: string,
+    paginationInput: DateIdPaginationInput,
   ): Promise<Feed[]>;
   delete(id: string): Promise<void>;
 }

--- a/src/domain/interface/feed/feeds.repository.ts
+++ b/src/domain/interface/feed/feeds.repository.ts
@@ -5,6 +5,7 @@ import { Feed, FeedPaginationInput } from 'src/domain/types/feed.types';
 export interface FeedsRepository {
   save(data: FeedEntity, images: FeedImageEntity[]): Promise<void>;
   update(id: string, data: Partial<FeedEntity>): Promise<void>;
+  findOneById(id: string): Promise<{ writerId: string } | null>;
   findOneByIdAndWriter(
     feedId: string,
     writerId: string,

--- a/src/domain/services/feed/blocked-feeds.service.ts
+++ b/src/domain/services/feed/blocked-feeds.service.ts
@@ -14,4 +14,8 @@ export class BlockedFeedsService {
     const blockedFeed = BlockedFeedEntity.create({ userId, feedId }, stdDate);
     await this.blockedFeedsRepository.save(blockedFeed);
   }
+
+  async unblock(userId: string, feedId: string) {
+    await this.blockedFeedsRepository.delete(userId, feedId);
+  }
 }

--- a/src/domain/services/feed/blocked-feeds.service.ts
+++ b/src/domain/services/feed/blocked-feeds.service.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { BlockedFeedEntity } from 'src/domain/entities/feed/blocked-feed.entity';
+import { BlockedFeedsRepository } from 'src/domain/interface/feed/blocked-feeds.repository';
+
+@Injectable()
+export class BlockedFeedsService {
+  constructor(
+    @Inject(BlockedFeedsRepository)
+    private readonly blockedFeedsRepository: BlockedFeedsRepository,
+  ) {}
+
+  async block(userId: string, feedId: string) {
+    const stdDate = new Date();
+    const blockedFeed = BlockedFeedEntity.create({ userId, feedId }, stdDate);
+    await this.blockedFeedsRepository.save(blockedFeed);
+  }
+}

--- a/src/domain/services/feed/blocked-feeds.service.ts
+++ b/src/domain/services/feed/blocked-feeds.service.ts
@@ -1,12 +1,17 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { BlockedFeedEntity } from 'src/domain/entities/feed/blocked-feed.entity';
+import { getFeedCursor } from 'src/domain/helpers/get-cursor';
 import { BlockedFeedsRepository } from 'src/domain/interface/feed/blocked-feeds.repository';
+import { FeedsRepository } from 'src/domain/interface/feed/feeds.repository';
+import { DateIdPaginationInput } from 'src/shared/types';
 
 @Injectable()
 export class BlockedFeedsService {
   constructor(
     @Inject(BlockedFeedsRepository)
     private readonly blockedFeedsRepository: BlockedFeedsRepository,
+    @Inject(FeedsRepository)
+    private readonly feedsRepository: FeedsRepository,
   ) {}
 
   async block(userId: string, feedId: string) {
@@ -17,5 +22,21 @@ export class BlockedFeedsService {
 
   async unblock(userId: string, feedId: string) {
     await this.blockedFeedsRepository.delete(userId, feedId);
+  }
+
+  async getBlockedFeeds(
+    userId: string,
+    paginationInput: DateIdPaginationInput,
+  ) {
+    const feeds = await this.feedsRepository.findBlockedFeedsByUserId(
+      userId,
+      paginationInput,
+    );
+    const nextCursor = getFeedCursor(feeds, paginationInput.limit);
+
+    return {
+      feeds,
+      nextCursor,
+    };
   }
 }

--- a/src/infrastructure/repositories/feed/blocked-feeds-prisma.repository.ts
+++ b/src/infrastructure/repositories/feed/blocked-feeds-prisma.repository.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { BlockedFeedEntity } from 'src/domain/entities/feed/blocked-feed.entity';
+import { BlockedFeedsRepository } from 'src/domain/interface/feed/blocked-feeds.repository';
+import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
+
+@Injectable()
+export class BlockedFeedsPrismaRepository implements BlockedFeedsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async save(data: BlockedFeedEntity): Promise<void> {
+    await this.prisma.blockedFeed.create({
+      data,
+    });
+  }
+}

--- a/src/infrastructure/repositories/feed/blocked-feeds-prisma.repository.ts
+++ b/src/infrastructure/repositories/feed/blocked-feeds-prisma.repository.ts
@@ -12,4 +12,15 @@ export class BlockedFeedsPrismaRepository implements BlockedFeedsRepository {
       data,
     });
   }
+
+  async delete(userId: string, feedId: string): Promise<void> {
+    await this.prisma.blockedFeed.delete({
+      where: {
+        userId_feedId: {
+          userId,
+          feedId,
+        },
+      },
+    });
+  }
 }

--- a/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
+++ b/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
@@ -107,7 +107,7 @@ export class FeedsPrismaRepository implements FeedsRepository {
       ])
       .where('f.id', 'in', () => subquery)
       .orderBy('f.created_at', feedCreatedAtOrder)
-      .orderBy('f.id')
+      .orderBy('f.id', 'asc')
       .orderBy('fi.index')
       .orderBy('gm.name')
       .execute();
@@ -207,7 +207,7 @@ export class FeedsPrismaRepository implements FeedsRepository {
       )
       .groupBy('f.id')
       .orderBy('f.created_at', feedCreatedAtOrder)
-      .orderBy('f.id')
+      .orderBy('f.id', 'asc')
       .limit(limit);
     return await this.findFeeds(order, query);
   }
@@ -240,7 +240,7 @@ export class FeedsPrismaRepository implements FeedsRepository {
       )
       .groupBy('fs.id')
       .orderBy('fs.created_at', feedCreatedAtOrder)
-      .orderBy('fs.id')
+      .orderBy('fs.id', 'asc')
       .limit(limit);
     return await this.findFeeds(order, query);
   }
@@ -256,7 +256,6 @@ export class FeedsPrismaRepository implements FeedsRepository {
       .innerJoin('feed as f', 'bf.feed_id', 'f.id')
       .select('f.id')
       .where('bf.user_id', '=', userId)
-      .where('f.created_at', '<', new Date(cursor.createdAt))
       .where((eb) =>
         eb.or([
           eb('f.created_at', '<', new Date(cursor.createdAt)),

--- a/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
+++ b/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
@@ -70,7 +70,6 @@ export class FeedsPrismaRepository implements FeedsRepository {
   }
 
   async findFeeds(
-    userId: string,
     feedPaginationInput: FeedPaginationInput,
     generateSubquery: (
       qb: ExpressionBuilder<DB & any, any>,
@@ -78,7 +77,6 @@ export class FeedsPrismaRepository implements FeedsRepository {
   ): Promise<Feed[]> {
     const { order } = feedPaginationInput;
     const feedCreatedAtOrder = order === 'DESC' ? 'desc' : 'asc';
-
     const rows = await this.txHost.tx.$kysely
       .selectFrom('feed as f')
       .innerJoin('user as u', 'f.writer_id', 'u.id')
@@ -175,7 +173,7 @@ export class FeedsPrismaRepository implements FeedsRepository {
     const feedCreatedAtOrder = order === 'DESC' ? 'desc' : 'asc';
     const cursorComparison = order === 'ASC' ? '>' : '<';
 
-    return await this.findFeeds(userId, feedPaginationInput, (qb) =>
+    return await this.findFeeds(feedPaginationInput, (qb) =>
       qb
         .selectFrom('feed as f')
         .select(['f.id'])
@@ -226,7 +224,7 @@ export class FeedsPrismaRepository implements FeedsRepository {
     const feedCreatedAtOrder = order === 'DESC' ? 'desc' : 'asc';
     const cursorComparison = order === 'ASC' ? '>' : '<';
 
-    return await this.findFeeds(userId, feedPaginationInput, (qb) =>
+    return await this.findFeeds(feedPaginationInput, (qb) =>
       qb
         .selectFrom('feed as fs')
         .select('fs.id')

--- a/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
+++ b/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
@@ -68,9 +68,10 @@ export class FeedsPrismaRepository implements FeedsRepository {
     });
   }
 
-  async findAllByUserId(
+  async findFeeds(
     userId: string,
     feedPaginationInput: FeedPaginationInput,
+    type: 'ALL' | 'MY',
   ): Promise<Feed[]> {
     const { cursor, limit, minDate, maxDate, order } = feedPaginationInput;
     const feedCreatedAtOrder = order === 'DESC' ? 'desc' : 'asc';
@@ -106,180 +107,84 @@ export class FeedsPrismaRepository implements FeedsRepository {
           .select(({ fn }) => [fn.count<number>('fc.id').as('comment_count')])
           .as('comment_count'),
       ])
-      .where('f.id', 'in', (qb) =>
-        qb
-          .selectFrom('feed as f')
-          .select(['f.id'])
-          .leftJoin('friend_feed_visibility as fv', 'f.id', 'fv.feed_id')
-          .leftJoin('gathering as g', 'f.gathering_id', 'g.id')
-          .leftJoin('gathering_participation as gp', 'g.id', 'gp.gathering_id')
-          .leftJoin('blocked_feed as bf', 'f.id', 'bf.feed_id')
-          .where('f.deleted_at', 'is', null)
-          .where('bf.user_id', 'is', null)
-          .where((eb) =>
-            eb.or([
-              eb.and([
-                eb('gp.participant_id', '=', userId),
+      .where('f.id', 'in', (qb) => {
+        if (type === 'MY') {
+          return qb
+            .selectFrom('feed as fs')
+            .select('fs.id')
+            .leftJoin('blocked_feed as bf', 'f.id', 'bf.feed_id')
+            .where('bf.user_id', 'is', null)
+            .where('fs.deleted_at', 'is', null)
+            .where('fs.writer_id', '=', userId)
+            .where('f.created_at', '>=', new Date(minDate))
+            .where('f.created_at', '<=', new Date(maxDate))
+            .where((eb) =>
+              eb.or([
                 eb(
-                  'gp.status',
-                  '=',
-                  sql<GatheringParticipationStatus>`${GatheringParticipationStatus.ACCEPTED}::"GatheringParticipationStatus"`,
+                  'f.created_at',
+                  cursorComparison,
+                  new Date(cursor.createdAt),
                 ),
+                eb.and([
+                  eb('f.created_at', '=', new Date(cursor.createdAt)),
+                  eb('f.id', '>', cursor.id),
+                ]),
               ]),
-              eb('g.host_user_id', '=', userId),
-              eb('fv.user_id', '=', userId),
-            ]),
-          )
-          .where('f.writer_id', '!=', userId)
-          .where('f.created_at', '>=', new Date(minDate))
-          .where('f.created_at', '<=', new Date(maxDate))
-          .where((eb) =>
-            eb.or([
-              eb('f.created_at', cursorComparison, new Date(cursor.createdAt)),
-              eb.and([
-                eb('f.created_at', '=', new Date(cursor.createdAt)),
-                eb('f.id', '>', cursor.id),
+            )
+            .groupBy('fs.id')
+            .orderBy('fs.created_at', feedCreatedAtOrder)
+            .orderBy('fs.id')
+            .limit(limit);
+        } else {
+          return qb
+            .selectFrom('feed as f')
+            .select(['f.id'])
+            .leftJoin('friend_feed_visibility as fv', 'f.id', 'fv.feed_id')
+            .leftJoin('gathering as g', 'f.gathering_id', 'g.id')
+            .leftJoin(
+              'gathering_participation as gp',
+              'g.id',
+              'gp.gathering_id',
+            )
+            .leftJoin('blocked_feed as bf', 'f.id', 'bf.feed_id')
+            .where('f.deleted_at', 'is', null)
+            .where('bf.user_id', 'is', null)
+            .where((eb) =>
+              eb.or([
+                eb.and([
+                  eb('gp.participant_id', '=', userId),
+                  eb(
+                    'gp.status',
+                    '=',
+                    sql<GatheringParticipationStatus>`${GatheringParticipationStatus.ACCEPTED}::"GatheringParticipationStatus"`,
+                  ),
+                ]),
+                eb('g.host_user_id', '=', userId),
+                eb('fv.user_id', '=', userId),
               ]),
-            ]),
-          )
-          .groupBy('f.id')
-          .orderBy('f.created_at', feedCreatedAtOrder)
-          .orderBy('f.id')
-          .limit(limit),
-      )
-      .orderBy('f.created_at', feedCreatedAtOrder)
-      .orderBy('f.id')
-      .orderBy('fi.index')
-      .orderBy('gm.name')
-      .execute();
-
-    const result: { [key: string]: Feed } = {};
-
-    rows.forEach((row) => {
-      if (!result.hasOwnProperty(row.id)) {
-        result[row.id] = {
-          id: row.id,
-          content: row.content,
-          commentCount: Number(row.comment_count ?? 0),
-          createdAt: row.created_at,
-          images: [],
-          gathering: null,
-          writer: {
-            id: row.writer_id,
-            name: row.writer_name,
-            accountId: row.writer_account_id,
-            profileImageUrl: row.writer_profile_image_url,
-          },
-        };
-      }
-
-      if (!result[row.id].images.some((image) => image === row.image_url)) {
-        result[row.id].images.push(row.image_url);
-      }
-
-      if (
-        !result[row.id].gathering &&
-        row.gathering_id &&
-        row.gathering_name &&
-        row.gathering_date
-      ) {
-        result[row.id].gathering = {
-          id: row.gathering_id,
-          name: row.gathering_name,
-          gatheringDate: row.gathering_date,
-          members: [],
-        };
-      }
-
-      if (
-        result[row.id].gathering &&
-        row.member_id &&
-        row.member_name &&
-        row.member_account_id &&
-        row.member_profile_image_url
-      ) {
-        const existingMember = result[row.id].gathering!.members.find(
-          (member) => member.id === row.member_id,
-        );
-
-        if (!existingMember) {
-          result[row.id].gathering!.members.push({
-            id: row.member_id,
-            name: row.member_name,
-            profileImageUrl: row.member_profile_image_url,
-            accountId: row.member_account_id,
-          });
+            )
+            .where('f.writer_id', '!=', userId)
+            .where('f.created_at', '>=', new Date(minDate))
+            .where('f.created_at', '<=', new Date(maxDate))
+            .where((eb) =>
+              eb.or([
+                eb(
+                  'f.created_at',
+                  cursorComparison,
+                  new Date(cursor.createdAt),
+                ),
+                eb.and([
+                  eb('f.created_at', '=', new Date(cursor.createdAt)),
+                  eb('f.id', '>', cursor.id),
+                ]),
+              ]),
+            )
+            .groupBy('f.id')
+            .orderBy('f.created_at', feedCreatedAtOrder)
+            .orderBy('f.id')
+            .limit(limit);
         }
-      }
-    });
-
-    return Object.values(result);
-  }
-
-  async findByUserId(
-    userId: string,
-    feedPaginationInput: FeedPaginationInput,
-  ): Promise<Feed[]> {
-    const { cursor, limit, minDate, maxDate, order } = feedPaginationInput;
-    const feedCreatedAtOrder = order === 'DESC' ? 'desc' : 'asc';
-    const cursorComparison = order === 'ASC' ? '>' : '<';
-
-    // NOTE 그룹원인지 확인
-    const rows = await this.txHost.tx.$kysely
-      .selectFrom('feed as f')
-      .innerJoin('user as w', 'w.id', 'f.writer_id')
-      .leftJoin('gathering as g', 'g.id', 'f.gathering_id')
-      .leftJoin('gathering_participation as gp', 'gp.gathering_id', 'g.id')
-      .leftJoin('feed_image as fi', 'fi.feed_id', 'f.id')
-      .leftJoin('user as gm', 'gm.id', 'gp.participant_id')
-      .select([
-        'f.id',
-        'f.content',
-        'f.created_at',
-        'w.id as writer_id',
-        'w.account_id as writer_account_id',
-        'w.name as writer_name',
-        'w.profile_image_url as writer_profile_image_url',
-        'fi.url as image_url',
-        'g.id as gathering_id',
-        'g.name as gathering_name',
-        'g.gathering_date',
-        'gm.id as member_id',
-        'gm.name as member_name',
-        'gm.profile_image_url as member_profile_image_url',
-        'gm.account_id as member_account_id',
-      ])
-      .select((qb) => [
-        qb
-          .selectFrom('feed_comment as fc')
-          .whereRef('fc.feed_id', '=', 'f.id')
-          .select(({ fn }) => [fn.count<number>('fc.id').as('comment_count')])
-          .as('comment_count'),
-      ])
-      .where('f.id', 'in', (qb) =>
-        qb
-          .selectFrom('feed as fs')
-          .select('fs.id')
-          .leftJoin('blocked_feed as bf', 'f.id', 'bf.feed_id')
-          .where('bf.user_id', 'is', null)
-          .where('fs.deleted_at', 'is', null)
-          .where('fs.writer_id', '=', userId)
-          .where('f.created_at', '>=', new Date(minDate))
-          .where('f.created_at', '<=', new Date(maxDate))
-          .where((eb) =>
-            eb.or([
-              eb('f.created_at', cursorComparison, new Date(cursor.createdAt)),
-              eb.and([
-                eb('f.created_at', '=', new Date(cursor.createdAt)),
-                eb('f.id', '>', cursor.id),
-              ]),
-            ]),
-          )
-          .groupBy('fs.id')
-          .orderBy('fs.created_at', feedCreatedAtOrder)
-          .orderBy('fs.id')
-          .limit(limit),
-      )
+      })
       .orderBy('f.created_at', feedCreatedAtOrder)
       .orderBy('f.id')
       .orderBy('fi.index')
@@ -334,6 +239,20 @@ export class FeedsPrismaRepository implements FeedsRepository {
     });
 
     return Object.values(result);
+  }
+
+  async findAllByUserId(
+    userId: string,
+    feedPaginationInput: FeedPaginationInput,
+  ): Promise<Feed[]> {
+    return await this.findFeeds(userId, feedPaginationInput, 'ALL');
+  }
+
+  async findByUserId(
+    userId: string,
+    feedPaginationInput: FeedPaginationInput,
+  ): Promise<Feed[]> {
+    return await this.findFeeds(userId, feedPaginationInput, 'MY');
   }
 
   async delete(id: string): Promise<void> {

--- a/src/infrastructure/repositories/users-prisma.repository.ts
+++ b/src/infrastructure/repositories/users-prisma.repository.ts
@@ -8,7 +8,6 @@ import type {
   UserDetail,
 } from 'src/domain/types/user.types';
 import { SearchInput } from 'src/infrastructure/types/user.types';
-import { userInfo } from 'os';
 
 @Injectable()
 export class UsersPrismaRepository implements UsersRepository {

--- a/src/modules/feed/feeds.module.ts
+++ b/src/modules/feed/feeds.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { BlockedFeedsRepository } from 'src/domain/interface/feed/blocked-feeds.repository';
 import { FeedsRepository } from 'src/domain/interface/feed/feeds.repository';
 import { FriendFeedVisibilitiesRepository } from 'src/domain/interface/feed/friend-feed-visibilities.repository';
+import { BlockedFeedsService } from 'src/domain/services/feed/blocked-feeds.service';
 import { FeedsReadService } from 'src/domain/services/feed/feeds-read.service';
 import { FeedsWriteService } from 'src/domain/services/feed/feeds-write.service';
+import { BlockedFeedsPrismaRepository } from 'src/infrastructure/repositories/feed/blocked-feeds-prisma.repository';
 import { FeedsPrismaRepository } from 'src/infrastructure/repositories/feed/feeds-prisma.repository';
 import { FriendFeedVisibilitiesPrismaRepository } from 'src/infrastructure/repositories/feed/friend-feed-visibilities-prisma.repository';
 import { FriendsModule } from 'src/modules/friend/friends.module';
@@ -15,10 +18,15 @@ import { FeedsController } from 'src/presentation/controllers/feed/feeds.control
   providers: [
     FeedsWriteService,
     FeedsReadService,
+    BlockedFeedsService,
     { provide: FeedsRepository, useClass: FeedsPrismaRepository },
     {
       provide: FriendFeedVisibilitiesRepository,
       useClass: FriendFeedVisibilitiesPrismaRepository,
+    },
+    {
+      provide: BlockedFeedsRepository,
+      useClass: BlockedFeedsPrismaRepository,
     },
   ],
 })

--- a/src/presentation/controllers/feed/feeds.controller.ts
+++ b/src/presentation/controllers/feed/feeds.controller.ts
@@ -213,8 +213,26 @@ export class FeedsController {
     await this.feedsWriteService.delete(feedId, userId);
   }
 
+  @ApiOperation({ summary: '피드 숨김' })
+  @ApiResponse({
+    status: 201,
+    description: '숨김 완료',
+  })
   @Post(':feedId/block')
   async block(@Param('feedId') feedId: string, @CurrentUser() userId: string) {
     await this.blockedFeedsService.block(userId, feedId);
+  }
+
+  @ApiOperation({ summary: '피드 숨김 해제' })
+  @ApiResponse({
+    status: 204,
+    description: '숨김 해제 완료',
+  })
+  @Delete(':feedId/block')
+  async unblock(
+    @Param('feedId') feedId: string,
+    @CurrentUser() userId: string,
+  ) {
+    await this.blockedFeedsService.unblock(userId, feedId);
   }
 }

--- a/src/presentation/controllers/feed/feeds.controller.ts
+++ b/src/presentation/controllers/feed/feeds.controller.ts
@@ -30,6 +30,7 @@ import { BlockedFeedsService } from 'src/domain/services/feed/blocked-feeds.serv
 import { FeedsReadService } from 'src/domain/services/feed/feeds-read.service';
 import { FeedsWriteService } from 'src/domain/services/feed/feeds-write.service';
 import { feedConverter } from 'src/presentation/converters/feed/feed.converters';
+import { BlockedFeedListRequest } from 'src/presentation/dto/feed/request/blocked-feed-list.request';
 import { CreateFriendFeedRequest } from 'src/presentation/dto/feed/request/create-friend-feed.request';
 import { CreateGatheringFeedRequest } from 'src/presentation/dto/feed/request/create-gathering-feed.request';
 import { FeedListRequest } from 'src/presentation/dto/feed/request/feed-list.request';
@@ -211,6 +212,21 @@ export class FeedsController {
     @CurrentUser() userId: string,
   ) {
     await this.feedsWriteService.delete(feedId, userId);
+  }
+
+  @ApiOperation({ summary: '숨김 피드 목록 조회' })
+  @ApiResponse({
+    status: 200,
+    description: '숨김 피드 목록 조회',
+    type: FeedListResponse,
+  })
+  @Get('blocked')
+  async getBlockedFeeds(
+    @Query() dto: BlockedFeedListRequest,
+    @CurrentUser() userId: string,
+  ): Promise<FeedListResponse> {
+    const domain = await this.blockedFeedsService.getBlockedFeeds(userId, dto);
+    return feedConverter.toListDto(domain);
   }
 
   @ApiOperation({ summary: '피드 숨김' })

--- a/src/presentation/controllers/feed/feeds.controller.ts
+++ b/src/presentation/controllers/feed/feeds.controller.ts
@@ -26,6 +26,7 @@ import { IMAGE_BASE_URL } from 'src/common/constant';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { CreateFeedImageMulterOptions } from 'src/configs/multer-s3/multer-options';
+import { BlockedFeedsService } from 'src/domain/services/feed/blocked-feeds.service';
 import { FeedsReadService } from 'src/domain/services/feed/feeds-read.service';
 import { FeedsWriteService } from 'src/domain/services/feed/feeds-write.service';
 import { feedConverter } from 'src/presentation/converters/feed/feed.converters';
@@ -45,6 +46,7 @@ export class FeedsController {
   constructor(
     private readonly feedsWriteService: FeedsWriteService,
     private readonly feedsReadService: FeedsReadService,
+    private readonly blockedFeedsService: BlockedFeedsService,
   ) {}
 
   @ApiOperation({
@@ -209,5 +211,10 @@ export class FeedsController {
     @CurrentUser() userId: string,
   ) {
     await this.feedsWriteService.delete(feedId, userId);
+  }
+
+  @Post(':feedId/block')
+  async block(@Param('feedId') feedId: string, @CurrentUser() userId: string) {
+    await this.blockedFeedsService.block(userId, feedId);
   }
 }

--- a/src/presentation/controllers/friend/friends.controller.ts
+++ b/src/presentation/controllers/friend/friends.controller.ts
@@ -177,7 +177,7 @@ export class FriendsController {
   @ApiResponse({
     status: 200,
     description: '검색 성공',
-    type: FriendRequestListResponse,
+    type: FriendListResponse,
   })
   @ApiResponse({
     status: 400,
@@ -187,7 +187,7 @@ export class FriendsController {
   async search(
     @Query() dto: SearchFriendRequest,
     @CurrentUser() userId: string,
-  ) {
+  ): Promise<FriendListResponse> {
     const { search, ...paginationInput } = dto;
     return await this.friendsService.search(userId, {
       search,

--- a/src/presentation/dto/feed/request/blocked-feed-list.request.ts
+++ b/src/presentation/dto/feed/request/blocked-feed-list.request.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { plainToInstance, Transform, Type } from 'class-transformer';
+import { IsInt, ValidateNested } from 'class-validator';
+import { FeedCursor } from './feed-list.request';
+
+export class BlockedFeedListRequest {
+  @ApiProperty({
+    type: FeedCursor,
+    description: '첫 번째 커서: { createdAt: 현재 날짜, id: uuid 아무 값이나 }',
+  })
+  @Transform(({ value }) => {
+    try {
+      const json = JSON.parse(value); // 문자열을 객체로 변환
+      return plainToInstance(FeedCursor, json);
+    } catch (e) {
+      throw new Error('커서 값을 파싱하는 데 실패했습니다.');
+    }
+  })
+  @ValidateNested({ message: '커서가 유효하지 않습니다.' })
+  @Type(() => FeedCursor)
+  readonly cursor: FeedCursor;
+
+  @ApiProperty({ example: 10 })
+  @IsInt({ message: 'limit이 정수가 아닙니다.' })
+  @Transform(({ value }) => Number(value), { toClassOnly: true })
+  readonly limit: number;
+}

--- a/src/presentation/dto/feed/request/feed-list.request.ts
+++ b/src/presentation/dto/feed/request/feed-list.request.ts
@@ -10,11 +10,11 @@ import {
 import { Order } from '../../shared';
 
 export class FeedCursor {
-  @ApiProperty()
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
   @IsDateString({}, { message: 'createdAt이 ISO8601 형식이 아닙니다.' })
   readonly createdAt: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'uuid' })
   @IsUUID(4, { message: 'id가 UUID가 아닙니다' })
   readonly id: string;
 }

--- a/src/presentation/dto/feed/response/feed-list.response.ts
+++ b/src/presentation/dto/feed/response/feed-list.response.ts
@@ -3,13 +3,13 @@ import { FeedCursor } from '../request/feed-list.request';
 import { User } from '../../shared';
 
 class Gathering {
-  @ApiProperty()
+  @ApiProperty({ example: 'uuid' })
   readonly id: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: '멋쟁이들의 모임' })
   readonly name: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: '2025-01-01T00:00:00.000Z' })
   readonly gatheringDate: Date;
 
   @ApiProperty({ type: [User] })
@@ -17,10 +17,10 @@ class Gathering {
 }
 
 export class Feed {
-  @ApiProperty()
+  @ApiProperty({ example: 'uuid' })
   readonly id: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: '우와 정말 재밌었다~~' })
   readonly content: string;
 
   @ApiProperty({
@@ -38,7 +38,7 @@ export class Feed {
   @ApiProperty()
   readonly writer: User;
 
-  @ApiProperty()
+  @ApiProperty({ example: '2024-12-28T00:00:00.000Z' })
   readonly createdAt: string;
 
   @ApiProperty({ type: Gathering, nullable: true })

--- a/test/e2e/feed2.e2e-spec.ts
+++ b/test/e2e/feed2.e2e-spec.ts
@@ -24,7 +24,7 @@ import { CreateFriendFeedRequest } from 'src/presentation/dto/feed/request/creat
 import { ResponseResult } from 'test/helpers/types';
 import { FeedListResponse } from 'src/presentation/dto/feed/response/feed-list.response';
 
-describe('UsersController (e2e)', () => {
+describe('FeedsController (e2e)', () => {
   let app: INestApplication;
   let prisma: PrismaService;
 
@@ -39,6 +39,7 @@ describe('UsersController (e2e)', () => {
   });
 
   afterEach(async () => {
+    await prisma.blockedFeed.deleteMany();
     await prisma.feedComment.deleteMany();
     await prisma.friendFeedVisibility.deleteMany();
     await prisma.friend.deleteMany();
@@ -204,7 +205,7 @@ describe('UsersController (e2e)', () => {
       });
 
       const feeds: Feed[] = [];
-      // 일반 피드
+      // 친구가 작성한 일반 피드 생성.
       for (let i = 0; i < 5; i++) {
         const feedEntity = generateFeedEntity(
           users[i].id,
@@ -227,6 +228,7 @@ describe('UsersController (e2e)', () => {
         });
         feeds.push(feed);
       }
+      // 내가 생성한 모임에 친구가 작성한 피드 생성.
       for (let i = 0; i < 5; i++) {
         const feedEntity = generateFeedEntity(
           users[i].id,
@@ -249,6 +251,7 @@ describe('UsersController (e2e)', () => {
         });
         feeds.push(feed);
       }
+      // 참가 중인 모임에 내가 작성한 피드 생성.
       for (let i = 0; i < 5; i++) {
         const feedEntity = generateFeedEntity(
           loginedUser!.id,
@@ -272,13 +275,13 @@ describe('UsersController (e2e)', () => {
         feeds.push(feed);
       }
 
-      // 일반 피드에 조회 가능 목록에 나를 추가
+      // 일반 피드에 조회 가능 목록에 나를 추가.
       const feedVisibilities = Array.from({ length: 5 }, (_, i) =>
         generateFriendFeedVisibilityEntity(feeds[i].id, loginedUser!.id),
       );
       await prisma.friendFeedVisibility.createMany({ data: feedVisibilities });
 
-      // 댓글 추가
+      // 댓글 추가.
       for (let i = 0; i < 7; i++) {
         await prisma.feedComment.create({
           data: generateFeedCommentEntity(feeds[0].id, loginedUser!.id),
@@ -304,6 +307,25 @@ describe('UsersController (e2e)', () => {
           data: generateFeedCommentEntity(feeds[14].id, loginedUser!.id),
         });
       }
+
+      // 숨김 피드 추가.
+      const blockedFeed1Id = feeds[0].id;
+      const blockedFeed2Id = feeds[10].id;
+      await prisma.blockedFeed.create({
+        data: {
+          userId: loginedUser!.id,
+          feedId: blockedFeed1Id,
+          createdAt: new Date(),
+        },
+      });
+      await prisma.blockedFeed.create({
+        data: {
+          userId: loginedUser!.id,
+          feedId: blockedFeed2Id,
+          createdAt: new Date(),
+        },
+      });
+      const expectedFeeds = feeds.filter((_, i) => i !== 0 && i !== 10);
 
       const order: Order = 'DESC';
       const minDate = new Date('2024-01-01T00:00:00.000Z').toISOString();
@@ -344,10 +366,10 @@ describe('UsersController (e2e)', () => {
       // TODO 검증 로직 추가해야함
       expect(allFeedStatus).toEqual(200);
       expect(myFeedStaus).toEqual(200);
-      expect(allFeeds.length).toEqual(10);
-      expect(myFeeds.length).toEqual(5);
+      expect(allFeeds.length).toEqual(9);
+      expect(myFeeds.length).toEqual(4);
       allFeeds.forEach((feed, i) => {
-        expect(feed.id).toEqual(feeds[i].id);
+        expect(feed.id).toEqual(expectedFeeds[i].id);
       });
     });
   });

--- a/test/e2e/feed2.e2e-spec.ts
+++ b/test/e2e/feed2.e2e-spec.ts
@@ -350,6 +350,9 @@ describe('FeedsController (e2e)', () => {
           )}&limit=${limit}`,
         )
         .set('Authorization', accessToken);
+      const blockedFeedsResponse = await request(app.getHttpServer())
+        .get(`/feeds/blocked?cursor=${JSON.stringify(cursor)}&limit=${limit}`)
+        .set('Authorization', accessToken);
 
       const {
         status: allFeedStatus,
@@ -357,17 +360,25 @@ describe('FeedsController (e2e)', () => {
       }: ResponseResult<FeedListResponse> = response;
       const {
         status: myFeedStaus,
-        body: myFeedBody,
+        body: myFeedsBody,
       }: ResponseResult<FeedListResponse> = myFeedsResponse;
+      const {
+        status: blockedFeedStatus,
+        body: blcokedFeedsBody,
+      }: ResponseResult<FeedListResponse> = blockedFeedsResponse;
 
       const { feeds: allFeeds, nextCursor: allFeedCursor } = allFeedsBody;
-      const { feeds: myFeeds, nextCursor: myFeedCursor } = myFeedBody;
+      const { feeds: myFeeds, nextCursor: myFeedCursor } = myFeedsBody;
+      const { feeds: blockedFeeds, nextCursor: blockedFeedCursor } =
+        blcokedFeedsBody;
 
       // TODO 검증 로직 추가해야함
       expect(allFeedStatus).toEqual(200);
       expect(myFeedStaus).toEqual(200);
+      expect(blockedFeedStatus).toEqual(200);
       expect(allFeeds.length).toEqual(9);
       expect(myFeeds.length).toEqual(4);
+      expect(blockedFeeds.length).toEqual(2);
       allFeeds.forEach((feed, i) => {
         expect(feed.id).toEqual(expectedFeeds[i].id);
       });


### PR DESCRIPTION
## 연관 이슈
- #87 

## 작업 내용
- 피드 숨김 기능.
- 숨김 해제 기능.
- 숨김 피드 조회 기능.
  - 정상 동작 e2e 작성
- 피드 목록 조회 공통 쿼리 함수로 추출.
  - where 절에서 조회 성격(all, my, blocked)에따라 분기했다가, 가독성 안 좋아서 매개변수로 서브쿼리 생성하는 콜백 받았다가, 타입 추론이 부실해져서 쿼리를 생성해서 넘기도록 결정.
  - 최종 3702999e6f95895922328c740794e83049577658