### PR TITLE
받은 약속 초대장에 보낸 약속 초대장 일부가 조회되는 현상 (그룹 약속에서만 발생)

### DIFF
--- a/src/domain/interface/group/groups.repository.ts
+++ b/src/domain/interface/group/groups.repository.ts
@@ -12,6 +12,9 @@ export interface GroupsRepository {
     groupId: string,
     ownerId: string,
   ): Promise<{ id: string } | null>;
+  /**
+   * 그룹장도 함꼐 모든 멤버를 조회
+   */
   findGroupMembersById(id: string): Promise<{ participantId: string }[]>;
   update(id: string, data: Partial<GroupEntity>): Promise<void>;
   delete(groupId: string): Promise<void>;

--- a/src/domain/services/gathering/gatherings-write.service.ts
+++ b/src/domain/services/gathering/gatherings-write.service.ts
@@ -61,11 +61,13 @@ export class GatheringsWriteService {
     prototype: GatheringPrototype,
     groupId: string | null,
   ) {
+    const { hostUserId } = prototype;
     if (!groupId) {
       throw new BadRequestException(GROUP_GATHERING_REQUIRED_GROUPID_MESSAGE);
     }
     const friendIds = await this.getGroupMemberIds(groupId);
-    await this.createTransaction(prototype, friendIds);
+    const filteredIds = friendIds.filter((userId) => userId !== hostUserId);
+    await this.createTransaction(prototype, filteredIds);
   }
 
   @Transactional()

--- a/src/infrastructure/repositories/group/groups-prisma.repository.ts
+++ b/src/infrastructure/repositories/group/groups-prisma.repository.ts
@@ -116,14 +116,22 @@ export class GroupsPrismaRepository implements GroupsRepository {
   }
 
   async findGroupMembersById(id: string): Promise<{ participantId: string }[]> {
-    return await this.txHost.tx.groupParticipation.findMany({
+    const result = await this.txHost.tx.group.findUnique({
       select: {
-        participantId: true,
+        groupParticipation: {
+          select: {
+            participantId: true,
+          },
+        },
+        ownerId: true,
       },
       where: {
-        groupId: id,
+        id,
       },
     });
+    return result
+      ? [...result.groupParticipation, { participantId: result.ownerId }]
+      : [];
   }
 
   async update(id: string, data: Partial<GroupEntity>): Promise<void> {

--- a/src/utils/filter/filter-id.ts
+++ b/src/utils/filter/filter-id.ts
@@ -1,0 +1,3 @@
+export const filterId = (targetId: string, Ids: string[]) => {
+  return Ids.filter((userId) => userId !== targetId);
+};


### PR DESCRIPTION
## 연관 이슈
- #92 

## 원인
그룹 선택 시 해당 그룹의 멤버들이 조회되고 해당 멤버에 대해 초대장을 생성함.
이때 조회된 멤버에 약속 생성자 자신도 포함되어 있어서 자신에 대한 초대도 생성되었음.

## 해결
멤버를 조회한 후 약속 생성자 자신의 id는 필터링하는 코드 추가.

## 작업 내용
- 자신의 id 필터링 하는 코드 추가.
- 약속 초대 시 자신에 대한 초대는 생성되지 않아야하는 테스트 케이스 추가 e2e
