### PR TITLE
Feat/impl user api

### DIFF
--- a/src/common/decorators/swagger/index.ts
+++ b/src/common/decorators/swagger/index.ts
@@ -1,4 +1,4 @@
-import { ApiQuery } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { UserCursor } from 'src/presentation/dto';
 
 export const ApiUserPaginationQuery = () => {
@@ -98,5 +98,18 @@ export const ApiGatheringQuery = () => {
       propertyKey,
       descriptor,
     );
+  };
+};
+
+export const ApiFileOperation = () => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    ApiOperation({
+      summary: '이미지 업로드',
+      description: '이미지 최대 용량 4MB',
+    })(target, propertyKey, descriptor);
   };
 };

--- a/src/domain/interface/users.repository.ts
+++ b/src/domain/interface/users.repository.ts
@@ -1,5 +1,10 @@
 import { UserEntity } from 'src/domain/entities/user/user.entity';
-import { User, UserBasicInfo, UserDetail } from 'src/domain/types/user.types';
+import {
+  Profile,
+  User,
+  UserBasicInfo,
+  UserDetail,
+} from 'src/domain/types/user.types';
 import { SearchInput } from 'src/infrastructure/types/user.types';
 
 export interface UsersRepository {
@@ -15,6 +20,7 @@ export interface UsersRepository {
     searchInput: SearchInput,
   ): Promise<User[]>;
   findDetailById(id: string): Promise<UserDetail | null>;
+  findProfileById(id: string): Promise<Profile | null>;
   update(data: Partial<UserEntity>): Promise<void>;
 }
 

--- a/src/domain/services/auth/auth.service.ts
+++ b/src/domain/services/auth/auth.service.ts
@@ -33,6 +33,7 @@ export class AuthService {
     }
 
     return {
+      id: user.id,
       accessToken: await this.generateToken(user.id),
       accountId: user.accountId,
       profileImageUrl: user.profileImageUrl,
@@ -52,6 +53,7 @@ export class AuthService {
     await this.usersRepository.save(user);
 
     return {
+      id: user.id,
       accessToken: await this.generateToken(user.id),
       accountId: user.accountId,
     };

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -60,6 +60,15 @@ export class UsersService {
     return user;
   }
 
+  async getProfile(id: string) {
+    const user = await this.usersRepository.findProfileById(id);
+    if (!user) {
+      throw new NotFoundException(NOT_FOUND_USER_MESSAGE);
+    }
+
+    return user;
+  }
+
   private async getUserByIdOrThrow(userId: string) {
     const user = await this.usersRepository.findOneById(userId);
     if (!user) {

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -78,7 +78,7 @@ export class UsersService {
     return user;
   }
 
-  private async checkDuplicateAccountId(accountId: string) {
+  async checkDuplicateAccountId(accountId: string) {
     const userByAccountId = await this.usersRepository.findOneByAccountId(
       accountId,
     );

--- a/src/domain/types/user.types.ts
+++ b/src/domain/types/user.types.ts
@@ -24,12 +24,19 @@ export interface User {
 }
 
 export interface UserDetail extends User {
-  groupCount: number;
-  feedCount: number;
-  friendCount: number;
+  readonly groupCount: number;
+  readonly feedCount: number;
+  readonly friendCount: number;
+}
+
+export interface Profile {
+  readonly id: string;
+  readonly accountId: string;
+  readonly name: string;
+  readonly profileImageUrl: string | null;
 }
 
 export interface SearchInput {
-  paginationInput: UserPaginationInput;
-  search: string;
+  readonly paginationInput: UserPaginationInput;
+  readonly search: string;
 }

--- a/src/infrastructure/repositories/users-prisma.repository.ts
+++ b/src/infrastructure/repositories/users-prisma.repository.ts
@@ -3,6 +3,7 @@ import { UserEntity } from 'src/domain/entities/user/user.entity';
 import { UsersRepository } from 'src/domain/interface/users.repository';
 import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
 import type {
+  Profile,
   User,
   UserBasicInfo,
   UserDetail,
@@ -162,6 +163,20 @@ export class UsersPrismaRepository implements UsersRepository {
           profileImageUrl: row.profile_image_url,
         }
       : null;
+  }
+
+  async findProfileById(id: string): Promise<Profile | null> {
+    return await this.prisma.user.findUnique({
+      select: {
+        id: true,
+        name: true,
+        accountId: true,
+        profileImageUrl: true,
+      },
+      where: {
+        id,
+      },
+    });
   }
 
   async update(data: Partial<UserEntity>): Promise<void> {

--- a/src/presentation/controllers/feed/feeds.controller.ts
+++ b/src/presentation/controllers/feed/feeds.controller.ts
@@ -51,8 +51,8 @@ export class FeedsController {
   ) {}
 
   @ApiOperation({
-    summary: '피드 사진 업로드',
-    description: 'files입니다 파일즈 ssssssss',
+    summary: '이미지 업로드',
+    description: 'files입니다 파일즈 ssssssss, 한 파일당 4MB 최대 5개.',
   })
   @ApiBody({ type: FileListRequest })
   @ApiResponse({

--- a/src/presentation/controllers/gathering/gatherings.controller.ts
+++ b/src/presentation/controllers/gathering/gatherings.controller.ts
@@ -22,7 +22,10 @@ import {
 } from '@nestjs/swagger';
 import { IMAGE_BASE_URL } from 'src/common/constant';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
-import { ApiGatheringQuery } from 'src/common/decorators/swagger';
+import {
+  ApiFileOperation,
+  ApiGatheringQuery,
+} from 'src/common/decorators/swagger';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { CreateGatheringInvitationImageMulterOptions } from 'src/configs/multer-s3/multer-options';
 import { GatheringInvitationsReadService } from 'src/domain/services/gathering/gathering-invitations-read.service';
@@ -50,7 +53,7 @@ export class GatheringsController {
     private readonly gatheringInvitationsReadService: GatheringInvitationsReadService,
   ) {}
 
-  @ApiOperation({ summary: '모임 초대장 이미지 업로드' })
+  @ApiFileOperation()
   @ApiBody({ type: FileRequest })
   @ApiResponse({
     status: 200,

--- a/src/presentation/controllers/group/groups.controller.ts
+++ b/src/presentation/controllers/group/groups.controller.ts
@@ -25,7 +25,10 @@ import {
 } from '@nestjs/swagger';
 import { IMAGE_BASE_URL } from 'src/common/constant';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
-import { ApiGroupPaginationQuery } from 'src/common/decorators/swagger';
+import {
+  ApiFileOperation,
+  ApiGroupPaginationQuery,
+} from 'src/common/decorators/swagger';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { CreateGroupCoverImageMulterOptions } from 'src/configs/multer-s3/multer-options';
 import { GroupCreateService } from 'src/domain/services/group/group-create.service';
@@ -48,7 +51,7 @@ export class GroupsController {
     private readonly groupsService: GroupsService,
   ) {}
 
-  @ApiOperation({ summary: '그룹 커버 이미지 업로드' })
+  @ApiFileOperation()
   @ApiBody({ type: FileRequest })
   @ApiResponse({
     status: 200,

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -21,7 +21,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
-import { ApiUserPaginationQuery } from 'src/common/decorators/swagger';
+import {
+  ApiFileOperation,
+  ApiUserPaginationQuery,
+} from 'src/common/decorators/swagger';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { CreateProfileImageMulterOptions } from 'src/configs/multer-s3/multer-options';
 import { UsersService } from 'src/domain/services/user/users.service';
@@ -42,7 +45,7 @@ import { UserProfileResponse } from 'src/presentation/dto/user/response/user-pro
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @ApiOperation({ summary: '프로필 사진 업로드' })
+  @ApiFileOperation()
   @ApiBody({ type: FileRequest })
   @ApiResponse({
     status: 200,

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -33,6 +33,7 @@ import { IMAGE_BASE_URL } from 'src/common/constant';
 import { ChangeProfileImageRequest } from 'src/presentation/dto/user/request/change-profile-image.request';
 import { ChangeAccountIdRequest } from 'src/presentation/dto';
 import { UserDetailResponse } from 'src/presentation/dto/user/response/user-detail.response';
+import { UserProfileResponse } from 'src/presentation/dto/user/response/user-profile.response';
 
 @ApiTags('/users')
 @ApiBearerAuth()
@@ -98,9 +99,32 @@ export class UsersController {
     description: '회원 상세 정보 조회 완료',
     type: UserDetailResponse,
   })
+  @ApiResponse({
+    status: 404,
+    description: '존재하지 않는 회원 번호',
+  })
   @Get('my')
   async getDetail(@CurrentUser() userId: string): Promise<UserDetailResponse> {
     return await this.usersService.getDetail(userId);
+  }
+
+  @ApiOperation({
+    summary: '회원 프로필 조회 (로그인 시 응답하는 회원 정보와 동일)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '회원 프로필 조회 완료',
+    type: UserProfileResponse,
+  })
+  @ApiResponse({
+    status: 404,
+    description: '존재하지 않는 회원 번호',
+  })
+  @Get('profile')
+  async getProfile(
+    @CurrentUser() userId: string,
+  ): Promise<UserProfileResponse> {
+    return await this.usersService.getProfile(userId);
   }
 
   @ApiOperation({ summary: '프로필 사진 변경' })

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -130,6 +130,23 @@ export class UsersController {
     return await this.usersService.getProfile(userId);
   }
 
+  @ApiOperation({
+    summary: '닉네임 중복 체크',
+    description: '상태 코드로만 판단하시면 됩니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용 가능한 닉네임',
+  })
+  @ApiResponse({
+    status: 409,
+    description: '이미 존재하는 닉네임',
+  })
+  @Get('availability')
+  async existAccountId(@Query('accountId') accountId: string) {
+    await this.usersService.checkDuplicateAccountId(accountId);
+  }
+
   @ApiOperation({ summary: '프로필 사진 변경' })
   @ApiResponse({
     status: 204,

--- a/src/presentation/dto/auth/request/register.request.ts
+++ b/src/presentation/dto/auth/request/register.request.ts
@@ -11,20 +11,21 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Provider } from '../../shared';
 
 export class RegisterRequest {
-  @ApiProperty()
+  @ApiProperty({ example: 'lighty@gmail.com' })
   @IsEmail({}, { message: '이메일 형식이 아닙니다.' })
   readonly email: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: '재은최' })
   // 최대 길이 미정
   @Length(1, 20)
   readonly name: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'good_orange' })
   @Length(5, 15, { message: '계정 아이디는 최소 5자 최대 15자만 가능합니다.' })
   readonly accountId: string;
 
   @ApiProperty({
+    example: 'https://cdn.lighty.today/image.com',
     type: 'string',
     nullable: true,
   })

--- a/src/presentation/dto/auth/response/login.response.ts
+++ b/src/presentation/dto/auth/response/login.response.ts
@@ -1,10 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginResponse {
-  @ApiProperty()
+  @ApiProperty({ example: 'uuid' })
+  readonly id: string;
+
+  @ApiProperty({ example: '토큰' })
   readonly accessToken: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'bad_orange' })
   readonly accountId: string;
 
   @ApiProperty({ type: 'string', nullable: true })

--- a/src/presentation/dto/auth/response/register.response.ts
+++ b/src/presentation/dto/auth/response/register.response.ts
@@ -1,9 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class RegisterResponse {
-  @ApiProperty()
+  @ApiProperty({ example: 'uuid' })
+  readonly id: string;
+
+  @ApiProperty({ example: '톡흔' })
   readonly accessToken: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'bad_orange' })
   readonly accountId: string;
 }

--- a/src/presentation/dto/user/index.ts
+++ b/src/presentation/dto/user/index.ts
@@ -2,6 +2,8 @@ export * from './request/search-user.request';
 export * from './request/user-pagination.request';
 export * from './request/change-profile-image.request';
 export * from './request/change-account-id.request';
+
 export * from './response/login-fail.response';
 export * from './response/search-user.response';
 export * from './response/user-detail.response';
+export * from './response/user-profile.response';

--- a/src/presentation/dto/user/response/user-profile.response.ts
+++ b/src/presentation/dto/user/response/user-profile.response.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserProfileResponse {
+  @ApiProperty({ example: 'uuid' })
+  readonly id: string;
+
+  @ApiProperty({ example: '최은제' })
+  readonly name: string;
+
+  @ApiProperty({ example: 'bad_orange' })
+  readonly accountId: string;
+
+  @ApiProperty({
+    example: 'https://cdn.lighty.today/image.com',
+    nullable: true,
+    type: 'string',
+  })
+  readonly profileImageUrl: string | null;
+}


### PR DESCRIPTION
## 연관 이슈
- #99 

## 작업 내용
- 로그인, 회원가입  응답에 회원 id 포함.
- 회원 프로필 조회 기능 구현. (로그인 시 응답하는 정보와 동일)
- 닉네임 중복 체크 api로 분리.
- swagger에 이미지 최대 용량 표기.