### PR TITLE
회원 삭제 및 그룹 생성 조회 정책 변경

### DIFF
--- a/prisma/generated/types.ts
+++ b/prisma/generated/types.ts
@@ -50,6 +50,49 @@ export const ReportTypes = {
   GROUP: 'GROUP',
 } as const;
 export type ReportTypes = (typeof ReportTypes)[keyof typeof ReportTypes];
+export type ActiveFeed = {
+  id: string;
+  writer_id: string;
+  gathering_id: string | null;
+  content: string;
+  created_at: Timestamp;
+  updated_at: Timestamp;
+  deleted_at: Timestamp | null;
+};
+export type ActiveFeedComment = {
+  id: string;
+  feed_id: string;
+  writer_id: string;
+  content: string;
+  created_at: Timestamp;
+  deleted_at: Timestamp | null;
+};
+export type ActiveGathering = {
+  id: string;
+  type: GatheringType;
+  group_id: string | null;
+  host_user_id: string;
+  name: string;
+  description: string;
+  gathering_date: Timestamp;
+  address: string;
+  invitation_image_url: string;
+  ended_at: Timestamp | null;
+  created_at: Timestamp;
+  updated_at: Timestamp;
+  deleted_at: Timestamp | null;
+};
+export type ActiveUser = {
+  id: string;
+  email: string;
+  provider: OAuthProvider;
+  name: string;
+  account_id: string;
+  profile_image_url: string | null;
+  created_at: Timestamp;
+  updated_at: Timestamp;
+  deleted_at: Timestamp | null;
+};
 export type BlockedFeed = {
   user_id: string;
   feed_id: string;
@@ -163,6 +206,10 @@ export type User = {
   deleted_at: Timestamp | null;
 };
 export type DB = {
+  active_feed: ActiveFeed;
+  active_feed_comment: ActiveFeedComment;
+  active_gathering: ActiveGathering;
+  active_user: ActiveUser;
   blocked_feed: BlockedFeed;
   feed: Feed;
   feed_comment: FeedComment;

--- a/prisma/migrations/20250211104552_add_active_view/migration.sql
+++ b/prisma/migrations/20250211104552_add_active_view/migration.sql
@@ -1,0 +1,20 @@
+-- Create Active View
+CREATE VIEW "active_user" AS
+  SELECT *
+  FROM "user" u
+  WHERE u.deleted_at IS NULL;
+
+CREATE VIEW "active_feed" AS
+  SELECT *
+  FROM "feed" f
+  WHERE f.deleted_at IS NULL;
+
+CREATE VIEW "active_feed_comment" AS
+  SELECT *
+  FROM "feed_comment" fc
+  WHERE fc.deleted_at IS NULL;
+
+CREATE VIEW "active_gathering" AS
+  SELECT *
+  FROM "gathering" g
+  WHERE g.deleted_at IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["views"]
 }
 
 generator kysely {
@@ -89,6 +90,22 @@ model User {
   @@map("user")
 }
 
+view ActiveUser {
+  id String @id
+  email String @db.VarChar(255) @unique
+  provider OAuthProvider
+  name String @db.VarChar(20)
+  accountId String @db.VarChar(15) @map("account_id") @unique
+  profileImageUrl String? @map("profile_image_url")
+  createdAt DateTime @map("created_at")
+  updatedAt DateTime @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  @@unique([email, deletedAt])
+  @@unique([accountId, deletedAt])
+  @@map("active_user")
+}
+
 model Gathering {
   id String @id
   type GatheringType
@@ -110,6 +127,24 @@ model Gathering {
   feeds Feed[]
 
   @@map("gathering")
+}
+
+view ActiveGathering {
+  id String @id
+  type GatheringType
+  groupId String? @map("group_id")
+  hostUserId String @map("host_user_id")
+  name String @db.VarChar(20)
+  description String @db.VarChar(40)
+  gatheringDate DateTime @map("gathering_date")
+  address String @db.VarChar(100)
+  invitationImageUrl String @map("invitation_image_url")
+  endedAt DateTime? @map("ended_at")
+  createdAt DateTime @map("created_at")
+  updatedAt DateTime @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  @@map("active_gathering")
 }
 
 model GatheringParticipation {
@@ -145,6 +180,18 @@ model Feed {
   @@map("feed")
 }
 
+view ActiveFeed {
+  id String @id
+  writerId String @map("writer_id")
+  gatheringId String? @map("gathering_id")
+  content String @db.VarChar(150)
+  createdAt DateTime @map("created_at")
+  updatedAt DateTime @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  @@map("active_feed")
+}
+
 model FeedImage {
   id String @id
   feedId String @map("feed_id")
@@ -169,6 +216,17 @@ model FeedComment {
   writer User @relation(fields: [writerId], references: [id])
 
   @@map("feed_comment")
+}
+
+model ActiveFeedComment {
+  id String @id
+  feedId String @map("feed_id")
+  writerId String @map("writer_id")
+  content String
+  createdAt DateTime @map("created_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  @@map("active_feed_comment")
 }
 
 model FriendFeedVisibility {

--- a/src/domain/interface/friend/friends.repository.ts
+++ b/src/domain/interface/friend/friends.repository.ts
@@ -6,7 +6,9 @@ import { FriendStatus, UserPaginationInput } from 'src/shared/types';
 
 export interface FriendsRepository {
   save(data: FriendEntity): Promise<void>;
-  findOneById(id: string): Promise<{ id: string; receiverId: string } | null>;
+  findOneById(
+    id: string,
+  ): Promise<{ id: string; receiverId: string; senderId: string } | null>;
   findFriendsByUserId(
     userId: string,
     paginationInput: UserPaginationInput,

--- a/src/domain/interface/group/group-participations.repository.ts
+++ b/src/domain/interface/group/group-participations.repository.ts
@@ -7,6 +7,10 @@ export interface GroupParticipationsRepository {
   findByUserIds(
     userIds: string[],
   ): Promise<{ id: string; status: GroupParticipationStatus }[]>;
+  /**
+   * 그룹장을 포함한 모든 멤버 조회.
+   */
+  findMembersByGroupId(groupId: string): Promise<{ participantId: string }[]>;
   delete(groupId: string, participantId: string): Promise<void>;
   update(id: string, data: Partial<GroupParticipationEntity>): Promise<void>;
 }

--- a/src/domain/interface/group/groups.repository.ts
+++ b/src/domain/interface/group/groups.repository.ts
@@ -12,10 +12,6 @@ export interface GroupsRepository {
     groupId: string,
     ownerId: string,
   ): Promise<{ id: string } | null>;
-  /**
-   * 그룹장도 함꼐 모든 멤버를 조회
-   */
-  findGroupMembersById(id: string): Promise<{ participantId: string }[]>;
   update(id: string, data: Partial<GroupEntity>): Promise<void>;
   delete(groupId: string): Promise<void>;
 }

--- a/src/domain/interface/users.repository.ts
+++ b/src/domain/interface/users.repository.ts
@@ -22,6 +22,7 @@ export interface UsersRepository {
   findDetailById(id: string): Promise<UserDetail | null>;
   findProfileById(id: string): Promise<Profile | null>;
   update(data: Partial<UserEntity>): Promise<void>;
+  delete(id: string): Promise<void>;
 }
 
 export const UsersRepository = Symbol('UsersRepository');

--- a/src/domain/services/friend/friends.service.ts
+++ b/src/domain/services/friend/friends.service.ts
@@ -137,18 +137,21 @@ export class FriendsService {
     });
   }
 
-  async reject(friendId: string, receiverId: string) {
-    await this.checkReceiver(friendId, receiverId);
+  async reject(friendId: string, userId: string) {
+    await this.checkReceiver(friendId, userId);
     await this.friendsRepository.delete(friendId);
   }
 
-  async checkReceiver(friendId: string, receiverId: string) {
+  async checkReceiver(friendId: string, userId: string) {
     const friendRequest = await this.friendsRepository.findOneById(friendId);
     if (!friendRequest) {
       throw new NotFoundException(NOT_FOUND_FRIEND_MESSAGE);
     }
 
-    if (friendRequest.receiverId !== receiverId) {
+    if (
+      friendRequest.receiverId !== userId &&
+      friendRequest.senderId !== userId
+    ) {
       throw new ForbiddenException(FORBIDDEN_MESSAGE);
     }
   }

--- a/src/domain/services/gathering/gatherings-write.service.ts
+++ b/src/domain/services/gathering/gatherings-write.service.ts
@@ -22,8 +22,8 @@ import {
 import { GatheringsRepository } from 'src/domain/interface/gathering/gatherings.repository';
 import { GatheringParticipationEntity } from 'src/domain/entities/gathering/gathering-participation.entity';
 import { GatheringParticipationsRepository } from 'src/domain/interface/gathering/gathering-participations.repository';
-import { GroupsRepository } from 'src/domain/interface/group/groups.repository';
 import { checkIsFriendAll } from 'src/domain/helpers/check-is-friend';
+import { GroupParticipationsRepository } from 'src/domain/interface/group/group-participations.repository';
 
 @Injectable()
 export class GatheringsWriteService {
@@ -34,8 +34,8 @@ export class GatheringsWriteService {
     private readonly gatheringParticipationsRepository: GatheringParticipationsRepository,
     @Inject(FriendsRepository)
     private readonly friendsRepository: FriendsRepository,
-    @Inject(GroupsRepository)
-    private readonly groupsRepository: GroupsRepository,
+    @Inject(GroupParticipationsRepository)
+    private readonly groupParticipationsRepository: GroupParticipationsRepository,
   ) {}
 
   async create(prototype: GatheringPrototype, friendIds: string[] | null) {
@@ -108,7 +108,8 @@ export class GatheringsWriteService {
   }
 
   private async getGroupMemberIds(groupId: string) {
-    const members = await this.groupsRepository.findGroupMembersById(groupId);
+    const members =
+      await this.groupParticipationsRepository.findMembersByGroupId(groupId);
     return members.map((member) => member.participantId);
   }
 

--- a/src/domain/services/group/group-create.service.ts
+++ b/src/domain/services/group/group-create.service.ts
@@ -41,12 +41,13 @@ export class GroupCreateService {
     );
     const stdDate = new Date();
     const group = GroupEntity.create(prototype, v4, new Date());
-    const groupParticipations = friendIds.map((participantId) =>
-      GroupParticipationEntity.create(
-        { groupId: group.id, participantId },
-        v4,
-        stdDate,
-      ),
+    const groupParticipations = [prototype.ownerId, ...friendIds].map(
+      (participantId) =>
+        GroupParticipationEntity.create(
+          { groupId: group.id, participantId },
+          v4,
+          stdDate,
+        ),
     );
 
     await this.createTransaction(group, groupParticipations);

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -99,4 +99,8 @@ export class UsersService {
       );
     }
   }
+
+  async delete(id: string) {
+    await this.usersRepository.delete(id);
+  }
 }

--- a/src/infrastructure/repositories/friend/friends.prisma.repository.ts
+++ b/src/infrastructure/repositories/friend/friends.prisma.repository.ts
@@ -21,11 +21,12 @@ export class FriendsPrismaRepository implements FriendsRepository {
 
   async findOneById(
     id: string,
-  ): Promise<{ id: string; receiverId: string } | null> {
+  ): Promise<{ id: string; receiverId: string; senderId: string } | null> {
     return await this.prisma.friend.findUnique({
       select: {
         id: true,
         receiverId: true,
+        senderId: true,
       },
       where: {
         id,

--- a/src/infrastructure/repositories/group/group-participations-prisma.repository.ts
+++ b/src/infrastructure/repositories/group/group-participations-prisma.repository.ts
@@ -43,6 +43,19 @@ export class GroupParticipationsPrismaRepository
     });
   }
 
+  async findMembersByGroupId(
+    groupId: string,
+  ): Promise<{ participantId: string }[]> {
+    return await this.txHost.tx.groupParticipation.findMany({
+      select: {
+        participantId: true,
+      },
+      where: {
+        groupId,
+      },
+    });
+  }
+
   async delete(groupId: string, participantId: string): Promise<void> {
     await this.txHost.tx.groupParticipation.delete({
       where: {

--- a/src/infrastructure/repositories/group/groups-prisma.repository.ts
+++ b/src/infrastructure/repositories/group/groups-prisma.repository.ts
@@ -109,25 +109,6 @@ export class GroupsPrismaRepository implements GroupsRepository {
     });
   }
 
-  async findGroupMembersById(id: string): Promise<{ participantId: string }[]> {
-    const result = await this.txHost.tx.group.findUnique({
-      select: {
-        groupParticipation: {
-          select: {
-            participantId: true,
-          },
-        },
-        ownerId: true,
-      },
-      where: {
-        id,
-      },
-    });
-    return result
-      ? [...result.groupParticipation, { participantId: result.ownerId }]
-      : [];
-  }
-
   async update(id: string, data: Partial<GroupEntity>): Promise<void> {
     await this.txHost.tx.group.update({
       data,

--- a/src/infrastructure/repositories/group/groups-prisma.repository.ts
+++ b/src/infrastructure/repositories/group/groups-prisma.repository.ts
@@ -82,8 +82,8 @@ export class GroupsPrismaRepository implements GroupsRepository {
         };
       }
 
-      // 자신의 참여 데이터는 멤버로 집계 X
-      if (row.member_id !== userId) {
+      // 그룹장은 멤버로 집계 X
+      if (row.member_id !== row.owner_id) {
         const member = {
           id: row.member_id,
           accountId: row.member_account_id,

--- a/src/infrastructure/repositories/users-prisma.repository.ts
+++ b/src/infrastructure/repositories/users-prisma.repository.ts
@@ -24,7 +24,7 @@ export class UsersPrismaRepository implements UsersRepository {
   }
 
   async findOneByEmail(email: string): Promise<UserBasicInfo | null> {
-    return await this.prisma.user.findUnique({
+    return await this.prisma.activeUser.findUnique({
       select: {
         id: true,
         email: true,
@@ -39,7 +39,7 @@ export class UsersPrismaRepository implements UsersRepository {
   }
 
   async findOneByAccountId(accountId: string): Promise<{ id: string } | null> {
-    return await this.prisma.user.findUnique({
+    return await this.prisma.activeUser.findUnique({
       select: {
         id: true,
       },
@@ -50,7 +50,7 @@ export class UsersPrismaRepository implements UsersRepository {
   async findOneById(
     id: string,
   ): Promise<{ id: string; createdAt: Date; updatedAt: Date } | null> {
-    return await this.prisma.user.findUnique({
+    return await this.prisma.activeUser.findUnique({
       select: {
         id: true,
         createdAt: true,
@@ -69,7 +69,7 @@ export class UsersPrismaRepository implements UsersRepository {
     const { search, paginationInput } = searchInput;
     const { cursor, limit } = paginationInput;
     const rows = await this.prisma.$kysely
-      .selectFrom('user as u')
+      .selectFrom('active_user as u')
       .leftJoin('friend as f', (join) =>
         join
           .on((eb) =>
@@ -225,6 +225,17 @@ export class UsersPrismaRepository implements UsersRepository {
     const { id, ...updateDate } = data;
     await this.prisma.user.update({
       data: updateDate,
+      where: {
+        id,
+      },
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.user.update({
+      data: {
+        deletedAt: new Date(),
+      },
       where: {
         id,
       },

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -206,7 +206,11 @@ export class UsersController {
     await this.usersService.updateAccountId(userId, dto.accountId);
   }
 
-  @ApiOperation({ summary: '탈퇴' })
+  @ApiOperation({
+    summary: '탈퇴',
+    description:
+      '아직 실행은 하면 안 돼여, 삭제 정책 다른 곳에 반영 안 했어요~~',
+  })
   @ApiResponse({
     status: 204,
     description: '탈퇴 성공',

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -203,5 +204,22 @@ export class UsersController {
     @CurrentUser() userId: string,
   ) {
     await this.usersService.updateAccountId(userId, dto.accountId);
+  }
+
+  @ApiOperation({ summary: '탈퇴' })
+  @ApiResponse({
+    status: 204,
+    description: '탈퇴 성공',
+  })
+  @ApiResponse({
+    status: 400,
+    description: '입력값 검증 실패',
+  })
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete()
+  async delete(@CurrentUser() userId: string) {
+    await this.usersService.delete(userId);
   }
 }

--- a/test/e2e/groups.e2e-spec.ts
+++ b/test/e2e/groups.e2e-spec.ts
@@ -160,7 +160,7 @@ describe('GroupsController (e2e)', () => {
       await prisma.group.createMany({
         data: [...ownGroups, ...otherGroups],
       });
-      // 내 참여 데이터 생성
+      // 내가 그룹장인 그룹에 자신의 참여 데이터 생성
       const myOwnGroupParticipations = ownGroups.map((group, i) =>
         generateGroupParticipationEntity(
           group.id,
@@ -240,7 +240,12 @@ describe('GroupsController (e2e)', () => {
       expect(nextCursor).toBeNull();
       expect(groups.length).toEqual(9);
       groups.forEach((group) => {
-        expect(group.members.length).toEqual(2);
+        if (group.name.includes('내그룹')) {
+          expect(group.members.length).toEqual(2);
+        }
+        if (group.name.includes('남그룹')) {
+          expect(group.members.length).toEqual(3);
+        }
       });
     });
   });

--- a/test/e2e/groups.e2e-spec.ts
+++ b/test/e2e/groups.e2e-spec.ts
@@ -14,11 +14,7 @@ import {
 } from 'test/helpers/generators';
 import { CreateGroupRequest } from 'src/presentation/dto/group/request/create-group.request';
 import { ResponseResult } from 'test/helpers/types';
-import {
-  AddGroupMemberRequest,
-  GroupListResponse,
-  UpdateDescriptionRequest,
-} from 'src/presentation/dto';
+import { AddGroupMemberRequest, GroupListResponse } from 'src/presentation/dto';
 import { Friend, User } from '@prisma/client';
 import { UpdateGroupRequest } from 'src/presentation/dto/group/request/update-group.request';
 
@@ -139,75 +135,99 @@ describe('GroupsController (e2e)', () => {
           accountId,
         },
       });
-      const groupParticipationStdDate1 = new Date('2025-01-01T00:00:00.000Z');
-      const groupParticipationStdDate2 = new Date('2025-01-01T12:00:00.000Z');
-      const groupParticipationStdDate3 = new Date('2024-12-21T12:00:00.000Z');
-      const user1 = await prisma.user.create({
-        data: generateUserEntity('test1@test.com', 'lighty_1', '이민수'), // 4
+      const users = Array.from({ length: 15 }, (_, i) =>
+        generateUserEntity(`other${i}@test.com`, `other_${i}`, `김철수${i}`),
+      );
+      await prisma.user.createMany({
+        data: users,
       });
-      const user2 = await prisma.user.create({
-        data: generateUserEntity('test2@test.com', 'lighty_2', '김진수'), // 1
+
+      const stdDates = [
+        new Date('2025-01-01T00:00:00.000Z'),
+        new Date('2025-01-01T12:00:00.000Z'),
+        new Date('2024-12-21T12:00:00.000Z'),
+        new Date('2024-12-21T11:59:00.000Z'),
+        new Date('2024-04-31T12:00:00.000Z'),
+      ];
+      // 내가 참여 중인 그룹
+      // 내가 생성한 그룹
+      const ownGroups = Array.from({ length: 5 }, (_, i) =>
+        generateGroupEntity(loginedUser!.id, `내그룹${i}`),
+      );
+      const otherGroups = Array.from({ length: 5 }, (_, i) =>
+        generateGroupEntity(users[i].id, `남그룹${i}`),
+      );
+      await prisma.group.createMany({
+        data: [...ownGroups, ...otherGroups],
       });
-      const user3 = await prisma.user.create({
-        data: generateUserEntity('test3@test.com', 'lighty_3', '이진수'), // 2
-      });
-      const friendRealtion1 = await prisma.friend.create({
-        data: generateFriendEntity(loginedUser!.id, user1.id, 'ACCEPTED'),
-      });
-      const friendRealtion2 = await prisma.friend.create({
-        data: generateFriendEntity(user2.id, loginedUser!.id, 'ACCEPTED'),
-      });
-      const friendRealtion3 = await prisma.friend.create({
-        data: generateFriendEntity(loginedUser!.id, user3.id, 'ACCEPTED'),
-      });
-      const group1 = await prisma.group.create({
-        data: generateGroupEntity(loginedUser!.id, '멋쟁이 그룹'),
-      });
-      const group1Participation1 = await prisma.groupParticipation.create({
-        data: generateGroupParticipationEntity(
-          group1.id,
-          user1.id,
-          groupParticipationStdDate2,
-        ),
-      });
-      const group1Participation2 = await prisma.groupParticipation.create({
-        data: generateGroupParticipationEntity(
-          group1.id,
-          user2.id,
-          groupParticipationStdDate2,
-        ),
-      });
-      const group1Participation3 = await prisma.groupParticipation.create({
-        data: generateGroupParticipationEntity(
-          group1.id,
-          user3.id,
-          groupParticipationStdDate2,
-        ),
-      });
-      const group2 = await prisma.group.create({
-        data: generateGroupEntity(user1.id, '안멋쟁이 그룹'),
-      });
-      const group2Participation1 = await prisma.groupParticipation.create({
-        data: generateGroupParticipationEntity(
-          group2.id,
+      // 내 참여 데이터 생성
+      const myOwnGroupParticipations = ownGroups.map((group, i) =>
+        generateGroupParticipationEntity(
+          group.id,
           loginedUser!.id,
-          groupParticipationStdDate1,
+          stdDates[i],
         ),
-      });
-      const group3 = await prisma.group.create({
-        data: generateGroupEntity(user2.id, '테스트 그룹'),
-      });
-      const group3Participation1 = await prisma.groupParticipation.create({
-        data: generateGroupParticipationEntity(
-          group3.id,
-          loginedUser!.id,
-          groupParticipationStdDate3,
+      );
+      const myOtherGroupParticipations = otherGroups
+        .map((group, i) =>
+          generateGroupParticipationEntity(
+            group.id,
+            loginedUser!.id,
+            stdDates[i],
+          ),
+        )
+        .filter((_, i) => i < 4);
+      // 내가 만든 그룹에 타회원 참여
+      const otherUserOwnGroupParticipations1 = ownGroups.map((group, i) =>
+        generateGroupParticipationEntity(
+          group.id,
+          users[i + 4].id,
+          stdDates[i],
         ),
+      );
+      // 내가 만든 그룹에 타회원 참여
+      const otherUserOwnGroupParticipations2 = ownGroups.map((group, i) =>
+        generateGroupParticipationEntity(
+          group.id,
+          users[i + 9].id,
+          stdDates[i],
+        ),
+      );
+      // 타회원 자신이 만든 그룹에 자신 참여
+      const otherGroupOwnerParticipations = otherGroups.map((group, i) =>
+        generateGroupParticipationEntity(group.id, users[i].id, stdDates[i]),
+      );
+      // 타회원이 만든 그룹에 타회원이 참여
+      const otherUserOtherGroupParticipations1 = otherGroups.map((group, i) =>
+        generateGroupParticipationEntity(
+          group.id,
+          users[i + 4].id,
+          stdDates[i],
+        ),
+      );
+      // 타회원이 만든 그룹에 타회원이 참여
+      const otherUserOtherGroupParticipations2 = otherGroups.map((group, i) =>
+        generateGroupParticipationEntity(
+          group.id,
+          users[i + 9].id,
+          stdDates[i],
+        ),
+      );
+      const participations = [
+        ...myOwnGroupParticipations,
+        ...myOtherGroupParticipations,
+        ...otherUserOwnGroupParticipations1,
+        ...otherUserOwnGroupParticipations2,
+        ...otherUserOtherGroupParticipations1,
+        ...otherUserOtherGroupParticipations2,
+      ];
+
+      await prisma.groupParticipation.createMany({
+        data: participations,
       });
-      const expectedGroups = [group1, group2, group3];
 
       const cursor = new Date('2025-01-01T12:00:00.001Z').toISOString();
-      const limit = 3;
+      const limit = 10;
 
       // when
       const response = await request(app.getHttpServer())
@@ -217,14 +237,11 @@ describe('GroupsController (e2e)', () => {
       const { groups, nextCursor } = body;
 
       expect(status).toEqual(200);
-      expect(nextCursor).toEqual(groupParticipationStdDate3.toISOString());
-      groups.forEach((group, i) => {
-        expect(group.id).toEqual(expectedGroups[i].id);
-        expect(group.name).toEqual(expectedGroups[i].name);
-        expect(group.description).toEqual(expectedGroups[i].description);
-        expect(group.gatheringCount).toEqual(expectedGroups[i].gatheringCount);
+      expect(nextCursor).toBeNull();
+      expect(groups.length).toEqual(9);
+      groups.forEach((group) => {
+        expect(group.members.length).toEqual(2);
       });
-      // 멤버도 검증해야하는데 귀찮다...
     });
   });
 

--- a/test/helpers/generators.ts
+++ b/test/helpers/generators.ts
@@ -45,10 +45,10 @@ export const generateFriendEntity = (
 export const generateGroupEntity = (
   ownerId: string,
   name = '멋쟁이들의 그룹',
-  description = '멋쟁이만 참여 가능',
-  groupImageUrl = 'https://image.com',
+  stdDate = new Date(),
 ): GroupEntity => {
-  const stdDate = new Date();
+  const groupImageUrl = 'https://image.com';
+  const description = '멋쟁이만 참여 가능';
   return GroupEntity.create(
     { name, description, groupImageUrl, ownerId },
     v4,


### PR DESCRIPTION
## 연관 이슈
- #105 

## 작업 내용
- soft delete를 하는 모든 테이블의 삭제되지 않은 정보만 저장하는 view 생성.
  - 아직 회원에만 적용함, 다른 도메인도 view에서 조회하도록 변경 필요.
- 회원 탈퇴.
  - 다른 도메인에 정책은 아직 적용 안 됨.
- 그룹 생성 조회 정책 변경
  - 생성:
    - 기존: 그룹장의 참여 데이터는 생성X -> 조회 시 그룹장인 경우도 조건에 함께 작성.
    - 변경: 그룹장의 참여 데이터도 생성 -> 그룹장인 조건 제거 및 그룹 멤버에서 그룹장 제거.
- 보낸 친구 요청 취소에서 403예외 발생하는 현생 수정.
  - 해당 친구 튜플에서 receiverId가 요청자가 아니면 403을 throw하고 있었음.