### PR TITLE
일반 피드 목록 조회에도 함께하는 회원 데이터 추가

### DIFF
--- a/src/domain/interface/feed/friend-feed-visibilities.repository.ts
+++ b/src/domain/interface/feed/friend-feed-visibilities.repository.ts
@@ -1,7 +1,14 @@
 import { FriendFeedVisibilityEntity } from 'src/domain/entities/feed/friend-feed-visibility.entity';
+import { User } from 'src/domain/types/user.types';
 
 export interface FriendFeedVisibilitiesRepository {
   saveMany(data: FriendFeedVisibilityEntity[]): Promise<void>;
+  findVisibleUsersByFeedIds(
+    feedIds: string[],
+    userId: string,
+  ): Promise<{
+    [feedId: string]: User[];
+  }>;
 }
 
 export const FriendFeedVisibilitiesRepository = Symbol(

--- a/src/domain/services/feed/feeds-read.service.ts
+++ b/src/domain/services/feed/feeds-read.service.ts
@@ -53,9 +53,7 @@ export class FeedsReadService {
     const feedsWithMembers = feeds.map((feed) => {
       const members = feed.gathering
         ? feed.withMembers
-        : withMembers[feed.id]
-        ? withMembers[feed.id]
-        : [];
+        : withMembers[feed.id] || [];
       return {
         ...feed,
         withMembers: members,

--- a/src/domain/services/feed/feeds-read.service.ts
+++ b/src/domain/services/feed/feeds-read.service.ts
@@ -1,13 +1,17 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { getFeedCursor } from 'src/domain/helpers/get-cursor';
 import { FeedsRepository } from 'src/domain/interface/feed/feeds.repository';
-import { FeedPaginationInput } from 'src/domain/types/feed.types';
+import { FriendFeedVisibilitiesRepository } from 'src/domain/interface/feed/friend-feed-visibilities.repository';
+import { Feed, FeedPaginationInput } from 'src/domain/types/feed.types';
+import { User } from 'src/domain/types/user.types';
 
 @Injectable()
 export class FeedsReadService {
   constructor(
     @Inject(FeedsRepository)
     private readonly feedsRepository: FeedsRepository,
+    @Inject(FriendFeedVisibilitiesRepository)
+    private readonly friendFeedVisibilitiesRepository: FriendFeedVisibilitiesRepository,
   ) {}
 
   async getAllFeeds(userId: string, feedPaginationInput: FeedPaginationInput) {
@@ -16,6 +20,19 @@ export class FeedsReadService {
 
   async getMyFeeds(userId: string, feedPaginationInput: FeedPaginationInput) {
     return await this.getFeeds(userId, feedPaginationInput, 'MY');
+  }
+
+  async getCommonFeedWithMember(
+    feeds: Feed[],
+    userId: string,
+  ): Promise<{ [feedId: string]: User[] }> {
+    const commonFeeds = feeds.filter((feed) => !feed.gathering);
+    return commonFeeds.length > 0
+      ? await this.friendFeedVisibilitiesRepository.findVisibleUsersByFeedIds(
+          commonFeeds.map((feed) => feed.id),
+          userId,
+        )
+      : {};
   }
 
   private async getFeeds(
@@ -32,9 +49,21 @@ export class FeedsReadService {
           )
         : await this.feedsRepository.findByUserId(userId, feedPaginationInput);
     const nextCursor = getFeedCursor(feeds, limit);
+    const withMembers = await this.getCommonFeedWithMember(feeds, userId);
+    const feedsWithMembers = feeds.map((feed) => {
+      const members = feed.gathering
+        ? feed.withMembers
+        : withMembers[feed.id]
+        ? withMembers[feed.id]
+        : [];
+      return {
+        ...feed,
+        withMembers: members,
+      };
+    });
 
     return {
-      feeds,
+      feeds: feedsWithMembers,
       nextCursor,
     };
   }

--- a/src/domain/types/feed.types.ts
+++ b/src/domain/types/feed.types.ts
@@ -23,8 +23,8 @@ export interface Feed {
     readonly id: string;
     readonly name: string;
     readonly gatheringDate: Date;
-    readonly members: User[];
   } | null;
+  readonly withMembers: User[];
 }
 
 export interface FeedPaginationInput {

--- a/src/infrastructure/repositories/feed/friend-feed-visibilities-prisma.repository.ts
+++ b/src/infrastructure/repositories/feed/friend-feed-visibilities-prisma.repository.ts
@@ -3,6 +3,7 @@ import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-pr
 import { Injectable } from '@nestjs/common';
 import { FriendFeedVisibilityEntity } from 'src/domain/entities/feed/friend-feed-visibility.entity';
 import { FriendFeedVisibilitiesRepository } from 'src/domain/interface/feed/friend-feed-visibilities.repository';
+import { User } from 'src/domain/types/user.types';
 
 @Injectable()
 export class FriendFeedVisibilitiesPrismaRepository
@@ -16,5 +17,41 @@ export class FriendFeedVisibilitiesPrismaRepository
     await this.txHost.tx.friendFeedVisibility.createMany({
       data,
     });
+  }
+
+  async findVisibleUsersByFeedIds(
+    feedIds: string[],
+    userId: string,
+  ): Promise<{
+    [feedId: string]: User[];
+  }> {
+    const rows = await this.txHost.tx.$kysely
+      .selectFrom('friend_feed_visibility as fv')
+      .innerJoin('active_user as au', 'au.id', 'fv.user_id')
+      .select([
+        'fv.feed_id',
+        'au.id',
+        'au.account_id',
+        'au.name',
+        'au.profile_image_url',
+      ])
+      .where('fv.feed_id', 'in', feedIds)
+      .where('fv.user_id', '!=', userId)
+      .execute();
+
+    const result: { [feedId: string]: User[] } = {};
+    rows.forEach((row) => {
+      if (!result.hasOwnProperty(row.feed_id)) {
+        result[row.feed_id] = [];
+      }
+      result[row.feed_id].push({
+        id: row.id,
+        accountId: row.account_id,
+        name: row.name,
+        profileImageUrl: row.profile_image_url,
+      });
+    });
+
+    return result;
   }
 }

--- a/src/presentation/dto/feed/response/feed-list.response.ts
+++ b/src/presentation/dto/feed/response/feed-list.response.ts
@@ -11,9 +11,6 @@ class Gathering {
 
   @ApiProperty({ example: '2025-01-01T00:00:00.000Z' })
   readonly gatheringDate: string;
-
-  @ApiProperty({ type: () => User, isArray: true })
-  readonly members: User[];
 }
 
 export class Feed {
@@ -43,6 +40,12 @@ export class Feed {
 
   @ApiProperty({ type: () => Gathering, nullable: true })
   readonly gathering: Gathering | null;
+
+  @ApiProperty({
+    type: () => [User],
+    description: '모임 피드에서는 모임원, 일반 피드에서는 공개한 친구.',
+  })
+  readonly withMembers: User[];
 }
 
 export class FeedListResponse {


### PR DESCRIPTION
## 연관 이슈
- #114

## 작업 내용
- 일반 피드 목록 조회에서 함께하는 회원 노출되도록 변경.
  - 기존에는 모임 피드에서만 노출했던 정보이기에 gathering 속성 내부에 members 속성으로 응답했지만, 
일반 피드에도 추가됨에 따라, depth를 하나 줄여서 withMemebers를 공통으로 사용하고 gathering에는 모임 정보만 포함하도록 변경.
  - 이미 join을 많이 하고 있어서 또 1:n 관계의 피드 공개 범위 테이블을 join하면 튜풀 수가 너무 늘어나서 공개 테이블에서 in 조건으로 검색하도록 구현함. cdb9b524de533103b20a76fde25cef8f828bf338
- 함께하는 회원 노출 정책 변경에 따라 테스트 수정.
- 함께하는 멤버에 자신은 노출되지 않도록 변경.