### PR TITLE
피드 댓글 신고 기능 구현

### DIFF
--- a/prisma/migrations/20250222082615_add_feed_comment_report_type/migration.sql
+++ b/prisma/migrations/20250222082615_add_feed_comment_report_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ReportTypes" ADD VALUE 'FEED_COMMENT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ enum ReportTypes {
   FRIEND
   FEED
   GROUP
+  FEED_COMMENT
 }
 
 model User {

--- a/src/common/pipes/validate-report-type.pipe.ts
+++ b/src/common/pipes/validate-report-type.pipe.ts
@@ -3,7 +3,12 @@ import { BadRequestException, PipeTransform } from '@nestjs/common';
 export class ValidateReportTypePipe implements PipeTransform {
   transform(value: any) {
     const provider = String(value).toUpperCase();
-    if (provider !== 'FRIEND' && provider !== 'GROUP' && provider !== 'FEED') {
+    if (
+      provider !== 'FRIEND' &&
+      provider !== 'GROUP' &&
+      provider !== 'FEED' &&
+      provider !== 'FEED_COMMENT'
+    ) {
       throw new BadRequestException(`${value} 신고는 지원하지 않습니다.`);
     }
 

--- a/src/domain/services/report/feed-comment-reports-write.service.ts
+++ b/src/domain/services/report/feed-comment-reports-write.service.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ReportEntity } from 'src/domain/entities/report/report.entity';
+import { ReportsRepository } from 'src/domain/interface/report/reports.repository';
+import { ReportPrototype } from 'src/domain/types/report.types';
+import { v4 } from 'uuid';
+
+@Injectable()
+export class FeedCommentReportsWriteService {
+  constructor(
+    @Inject(ReportsRepository)
+    private readonly reportsRepository: ReportsRepository,
+  ) {}
+
+  async report(prototype: ReportPrototype) {
+    const stdDate = new Date();
+    const report = ReportEntity.create(prototype, v4, stdDate);
+    await this.reportsRepository.save(report);
+  }
+}

--- a/src/modules/feed-comment/feed-comments.module.ts
+++ b/src/modules/feed-comment/feed-comments.module.ts
@@ -5,11 +5,12 @@ import { FeedCommentsService } from 'src/domain/services/feed-comment/feed-comme
 import { FeedCommentPrismaRepository } from 'src/infrastructure/repositories/feed-comment/feed-comment-prisma.repository';
 import { FeedsModule } from 'src/modules/feed/feeds.module';
 import { NotificationsModule } from 'src/modules/notification/notifications.module';
+import { ReportsModule } from 'src/modules/report/reports.module';
 import { UsersModule } from 'src/modules/user/users.module';
 import { FeedCommentController } from 'src/presentation/controllers/feed-comment/feed-comment.controller';
 
 @Module({
-  imports: [UsersModule, NotificationsModule, FeedsModule],
+  imports: [UsersModule, NotificationsModule, FeedsModule, ReportsModule],
   controllers: [FeedCommentController],
   providers: [
     FeedCommentCreationUseCase,

--- a/src/modules/report/reports.module.ts
+++ b/src/modules/report/reports.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ReportsRepository } from 'src/domain/interface/report/reports.repository';
+import { FeedCommentReportsWriteService } from 'src/domain/services/report/feed-comment-reports-write.service';
 import { FeedReportsWriteService } from 'src/domain/services/report/feed-reports-write.service';
 import { FriendReportsWriteSerivce } from 'src/domain/services/report/friend-reports-write.service';
 import { GroupReportsWriteService } from 'src/domain/services/report/group-reports.write.service';
@@ -22,6 +23,7 @@ import { ReportsController } from 'src/presentation/controllers/report/reports.c
     FriendReportsWriteSerivce,
     GroupReportsWriteService,
     FeedReportsWriteService,
+    FeedCommentReportsWriteService,
     { provide: ReportsRepository, useClass: ReportsPrismaRepository },
   ],
 })

--- a/src/presentation/controllers/report/reports.controller.ts
+++ b/src/presentation/controllers/report/reports.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -7,14 +7,12 @@ import {
 } from '@nestjs/swagger';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { AuthGuard } from 'src/common/guards/auth.guard';
-import { ValidateReportTypePipe } from 'src/common/pipes/validate-report-type.pipe';
 import { FeedCommentReportsWriteService } from 'src/domain/services/report/feed-comment-reports-write.service';
 import { FeedReportsWriteService } from 'src/domain/services/report/feed-reports-write.service';
 import { FriendReportsWriteSerivce } from 'src/domain/services/report/friend-reports-write.service';
 import { GroupReportsWriteService } from 'src/domain/services/report/group-reports.write.service';
 import { ReportPrototype } from 'src/domain/types/report.types';
 import { CreateReportRequest } from 'src/presentation/dto/report/request/create-report.request';
-import { ReportTypes } from 'src/shared/types';
 
 @ApiTags('/reports')
 @ApiBearerAuth()

--- a/src/presentation/controllers/report/reports.controller.ts
+++ b/src/presentation/controllers/report/reports.controller.ts
@@ -8,6 +8,7 @@ import {
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { ValidateReportTypePipe } from 'src/common/pipes/validate-report-type.pipe';
+import { FeedCommentReportsWriteService } from 'src/domain/services/report/feed-comment-reports-write.service';
 import { FeedReportsWriteService } from 'src/domain/services/report/feed-reports-write.service';
 import { FriendReportsWriteSerivce } from 'src/domain/services/report/friend-reports-write.service';
 import { GroupReportsWriteService } from 'src/domain/services/report/group-reports.write.service';
@@ -25,6 +26,7 @@ export class ReportsController {
     private readonly friendReportWriteService: FriendReportsWriteSerivce,
     private readonly groupReportWriteService: GroupReportsWriteService,
     private readonly feedReportsWriteService: FeedReportsWriteService,
+    private readonly feedCommentReportsWriteService: FeedCommentReportsWriteService,
   ) {}
 
   @ApiOperation({ summary: '신고' })
@@ -44,6 +46,8 @@ export class ReportsController {
       ? await this.friendReportWriteService.report(input)
       : type === 'GROUP'
       ? await this.groupReportWriteService.report(input)
-      : await this.feedReportsWriteService.report(input);
+      : type === 'FEED'
+      ? await this.feedReportsWriteService.report(input)
+      : await this.feedCommentReportsWriteService.report(input);
   }
 }

--- a/src/presentation/controllers/report/reports.controller.ts
+++ b/src/presentation/controllers/report/reports.controller.ts
@@ -34,13 +34,13 @@ export class ReportsController {
     status: 201,
     description: '신고 완료',
   })
-  @Post(':type')
+  @Post()
   async reportFriend(
-    @Param('type', ValidateReportTypePipe) type: ReportTypes,
     @Body() dto: CreateReportRequest,
     @CurrentUser() userId: string,
   ) {
     // TODO service 코드 수정 후 분기 제거하고 레이어 나누기.
+    const { type } = dto;
     const input: ReportPrototype = { ...dto, reporterId: userId };
     type === 'FRIEND'
       ? await this.friendReportWriteService.report(input)

--- a/src/presentation/dto/package.json
+++ b/src/presentation/dto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighty-type",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "lighty dto type",
   "typings": "./types/index.d.ts",
   "files": [

--- a/src/presentation/dto/report/request/create-report.request.ts
+++ b/src/presentation/dto/report/request/create-report.request.ts
@@ -22,7 +22,7 @@ export class CreateReportRequest {
     enum: ['FRIEND', 'GROUP', 'FEED'],
     example: 'FRIEND',
   })
-  @IsIn(['FRIEND', 'GROUP', 'FEED'], {
+  @IsIn(['FRIEND', 'GROUP', 'FEED', 'FEED_COMMENT'], {
     message: 'type은 FRIEND, GROUP, FEED만 가능합니다.',
   })
   @Transform(({ value }) => value.toUpperCase(), { toClassOnly: true })

--- a/src/presentation/dto/report/request/create-report.request.ts
+++ b/src/presentation/dto/report/request/create-report.request.ts
@@ -19,11 +19,11 @@ export class CreateReportRequest {
   @ApiProperty({
     description: '신고 종류',
     type: 'string',
-    enum: ['FRIEND', 'GROUP', 'FEED'],
+    enum: ['FRIEND', 'GROUP', 'FEED', 'FEED_COMMENT'],
     example: 'FRIEND',
   })
   @IsIn(['FRIEND', 'GROUP', 'FEED', 'FEED_COMMENT'], {
-    message: 'type은 FRIEND, GROUP, FEED만 가능합니다.',
+    message: 'type은 FRIEND, GROUP, FEED, FEED_COMMENT만 가능합니다.',
   })
   @Transform(({ value }) => value.toUpperCase(), { toClassOnly: true })
   readonly type: ReportTypes;

--- a/src/presentation/dto/shared/index.ts
+++ b/src/presentation/dto/shared/index.ts
@@ -60,5 +60,5 @@ export type Provider = 'GOOGLE' | 'KAKAO' | 'APPLE';
 export type FriendStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'REPORTED';
 export type GatheringType = 'GROUP' | 'FRIEND';
 export type Order = 'DESC' | 'ASC';
-export type ReportTypes = 'FRIEND' | 'FEED' | 'GROUP';
+export type ReportTypes = 'FRIEND' | 'FEED' | 'GROUP' | 'FEED_COMMENT';
 export type FriendRequestStatus = 'SENT' | 'RECEIVED' | 'NONE';

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -4,7 +4,7 @@ export type GatheringType = 'GROUP' | 'FRIEND';
 export type GatheringParticipationStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED';
 export type GroupParticipationStatus = 'ACCEPTED' | 'REPORTED';
 export type Order = 'DESC' | 'ASC';
-export type ReportTypes = 'FRIEND' | 'FEED' | 'GROUP';
+export type ReportTypes = 'FRIEND' | 'FEED' | 'GROUP' | 'FEED_COMMENT';
 export type FriendRequestStatus = 'SENT' | 'RECEIVED' | 'NONE';
 
 export interface UserPaginationInput {

--- a/test/e2e/report.e2e-spec.ts
+++ b/test/e2e/report.e2e-spec.ts
@@ -91,18 +91,19 @@ describe('ReportsController (e2e)', () => {
         reportedId: reportedUser.id,
         type: 'FRIEND',
       };
-      const type: ReportTypes = 'FRIEND';
 
       // when
       const response = await request(app.getHttpServer())
-        .post(`/reports/${type}`)
+        .post('/reports')
         .send(dto)
         .set('Authorization', accessToken);
       const { status } = response;
+      const report = await prisma.report.findMany();
       const afterReportInvitation =
         await prisma.gatheringParticipation.findMany();
 
       expect(status).toEqual(201);
+      expect(report.length).toEqual(1);
       expect(afterReportInvitation.length).toEqual(0);
     });
 
@@ -130,13 +131,14 @@ describe('ReportsController (e2e)', () => {
       };
 
       const response = await request(app.getHttpServer())
-        .post(`/reports/${dto.type}`)
+        .post('/reports')
         .send(dto)
         .set('Authorization', accessToken);
-      const { status, body } = response;
-      console.log(body);
+      const { status } = response;
+      const report = await prisma.report.findMany();
 
       expect(status).toEqual(201);
+      expect(report.length).toEqual(1);
     });
   });
 });


### PR DESCRIPTION
## 작업 내용
- 피드 댓글 신고 기능 구현
- 신고 api endpoint 변경
  - 기존: /reports/{type}
  - 변경: /reports
  - 바디에서 이미 받고 있는 타입을 path param으로 받고 있었음