### PR TITLE
s3 presigned url 구현

### DIFF
--- a/src/infrastructure/aws/s3/s3-presigned-manager.ts
+++ b/src/infrastructure/aws/s3/s3-presigned-manager.ts
@@ -1,0 +1,38 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { Injectable } from '@nestjs/common';
+import { v4 } from 'uuid';
+
+@Injectable()
+export class S3PresignedManager {
+  private readonly s3Client: S3Client;
+  private readonly bucketName: string;
+
+  constructor() {
+    this.s3Client = new S3Client({
+      region: String(process.env.AWS_BUCKET_REGION),
+      credentials: {
+        accessKeyId: String(process.env.AWS_ACCESS_KEY_ID),
+        secretAccessKey: String(process.env.AWS_SECRET_ACCESS_KEY),
+      },
+    });
+    this.bucketName = String(process.env.AWS_BUCKEY_NAME);
+  }
+
+  async getPresignedUrl(path: string, expiresIn = 30) {
+    const key = `${path}/${v4()}`;
+    const command = new PutObjectCommand({
+      Bucket: this.bucketName,
+      Key: key,
+      ContentType: 'image/*',
+    });
+
+    const presignedUrl = await getSignedUrl(this.s3Client, command, {
+      expiresIn,
+    });
+    return {
+      presignedUrl,
+      key,
+    };
+  }
+}

--- a/src/infrastructure/aws/s3/s3.module.ts
+++ b/src/infrastructure/aws/s3/s3.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { S3PresignedManager } from 'src/infrastructure/aws/s3/s3-presigned-manager';
+
+@Module({
+  providers: [S3PresignedManager],
+  exports: [S3PresignedManager],
+})
+export class S3Module {}


### PR DESCRIPTION
## 작업 내용
- presigned url 발급 기능 구현.

## 특이 사항
- 기능만 구현하고 적용은 아직 안 함
- { presignedUrl, key } 형태로 응답 중인데, presignedUrl로 업로드하고 성공 시 `${cdnUrl}${key}` 형태로 저장하면 됨.