### PR TITLE
cloudwatch에 로그가 전송되지 않던 현상 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,8 @@ import { FeedCommentsModule } from 'src/modules/feed-comment/feed-comments.modul
 import { NotificationsModule } from 'src/modules/notification/notifications.module';
 import { ReportsModule } from 'src/modules/report/reports.module';
 import { ListenersModule } from 'src/infrastructure/event/listeners/listeners.module';
+import { WinstonModule } from 'nest-winston';
+import { windstonOptions } from 'src/configs/winston/winston-options';
 
 @Module({
   imports: [
@@ -27,6 +29,7 @@ import { ListenersModule } from 'src/infrastructure/event/listeners/listeners.mo
       isGlobal: true,
       validationSchema,
     }),
+    WinstonModule.forRoot(windstonOptions),
     ClsModule.forRoot(clsOptions),
     SentryModule.forRoot(),
     PrismaModule,

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -4,10 +4,12 @@ import {
   ExceptionFilter,
   HttpException,
   HttpStatus,
-  Logger,
+  Inject,
 } from '@nestjs/common';
 import { SentryExceptionCaptured } from '@sentry/nestjs';
 import { Request, Response } from 'express';
+import { Logger } from 'winston';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { BadRequestException } from 'src/domain/error/exceptions/bad-request.exception';
 import { ConflictException } from 'src/domain/error/exceptions/conflice.exception';
 import { DomainException } from 'src/domain/error/exceptions/domain.exception';
@@ -16,7 +18,10 @@ import { UnprocessableException } from 'src/domain/error/exceptions/unprocessabl
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
-  private readonly logger = new Logger('Exception Filter');
+  constructor(
+    @Inject(WINSTON_MODULE_PROVIDER)
+    private readonly logger: Logger,
+  ) {}
 
   @SentryExceptionCaptured()
   catch(exception: Error, host: ArgumentsHost) {

--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -12,8 +12,6 @@ import { Logger } from 'winston';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
-  // readonly logger: Logger = new Logger('Logging Interceptor');
-
   constructor(
     @Inject(WINSTON_MODULE_PROVIDER)
     private readonly logger: Logger,
@@ -33,9 +31,7 @@ export class LoggingInterceptor implements NestInterceptor {
       tap(() => {
         const duration = Date.now() - startTime;
         if (process.env.NODE_ENV !== 'test') {
-          this.logger.info(
-            JSON.stringify({ ...message, duration: `${duration}ms` }, null, 2),
-          );
+          this.logger.info({ ...message, duration: `${duration}ms` });
         }
       }),
     );

--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -1,16 +1,23 @@
 import {
   CallHandler,
   ExecutionContext,
+  Inject,
   Injectable,
-  Logger,
   NestInterceptor,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Observable, tap } from 'rxjs';
+import { Logger } from 'winston';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
-  readonly logger: Logger = new Logger('Logging Interceptor');
+  // readonly logger: Logger = new Logger('Logging Interceptor');
+
+  constructor(
+    @Inject(WINSTON_MODULE_PROVIDER)
+    private readonly logger: Logger,
+  ) {}
 
   intercept(
     context: ExecutionContext,
@@ -26,7 +33,9 @@ export class LoggingInterceptor implements NestInterceptor {
       tap(() => {
         const duration = Date.now() - startTime;
         if (process.env.NODE_ENV !== 'test') {
-          this.logger.log({ ...message, duration: `${duration}ms` });
+          this.logger.info(
+            JSON.stringify({ ...message, duration: `${duration}ms` }, null, 2),
+          );
         }
       }),
     );


### PR DESCRIPTION
## 원인
- 기본 로거로 주입한 winston 로거의 log 함수를 info 레벨로 인식 못 함.
  -> WINSTON_PROVIDER로 로거 주입해서 사용.
- transports.Console 설정과 기본 로그 설정이 충돌해서 json 로그가 저장되지 못 함.
  -> Console 설정이 기본 로거 설정과 동일하여 제거해줌.