### PR TITLE
애플 로그인 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "faker": "^6.6.6",
         "firebase-admin": "^13.1.0",
         "joi": "^17.13.3",
+        "jwks-rsa": "^3.1.0",
         "kysely": "^0.27.5",
         "multer-s3": "^3.0.1",
         "nest-winston": "^1.9.7",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "faker": "^6.6.6",
     "firebase-admin": "^13.1.0",
     "joi": "^17.13.3",
+    "jwks-rsa": "^3.1.0",
     "kysely": "^0.27.5",
     "multer-s3": "^3.0.1",
     "nest-winston": "^1.9.7",

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -3,6 +3,7 @@ export const GOOGLE_USER_INFO_URL =
   'https://www.googleapis.com/oauth2/v3/userinfo';
 export const KAKAO_USER_INFO_URL =
   'https://kapi.kakao.com/v2/user/me?secure_resource=true';
+export const APPLE_KEYS_URL = 'https://appleid.apple.com/auth/keys';
 
 export const notificationTypes = {
   GATHERING_INVITATION_RECEIVED: 'GATHERING_INVITATION_RECEIVED',

--- a/src/domain/services/auth/auth.service.ts
+++ b/src/domain/services/auth/auth.service.ts
@@ -277,19 +277,18 @@ export class AuthService {
       const { deletedAt } = user;
 
       if (deletedAt) {
-        if (calcDateDiff(today, deletedAt, 'd') < 30) {
-          if (user.provider !== provider) {
-            throw new RegisterdOtherPlatformException(oauthUserInfo);
-          }
-          return user;
+        if (calcDateDiff(today, deletedAt, 'd') >= 30) {
+          throw new UserNotRegisteredException(oauthUserInfo);
         }
-        throw new UserNotRegisteredException(oauthUserInfo);
-      } else {
         if (user.provider !== provider) {
           throw new RegisterdOtherPlatformException(oauthUserInfo);
         }
+        return user;
       }
 
+      if (user.provider !== provider) {
+        throw new RegisterdOtherPlatformException(oauthUserInfo);
+      }
       return user;
     } catch (e: unknown) {
       if (e instanceof UserNotFoundException) {

--- a/src/infrastructure/auth/context/oauth-context.ts
+++ b/src/infrastructure/auth/context/oauth-context.ts
@@ -3,11 +3,14 @@ import { Provider } from 'src/shared/types';
 import { GoogleStrategy } from '../strategies/google-strategy';
 import { KakaoStrategy } from 'src/infrastructure/auth/strategies/kakao-strategy';
 import { OauthUserInfo } from 'src/infrastructure/auth/strategies/oauth-strategy';
+import { AppleStrategy } from 'src/infrastructure/auth/strategies/apple-strategy';
+
 @Injectable()
 export class OauthContext {
   constructor(
     private readonly googleStrategy: GoogleStrategy,
     private readonly kakaoStrategy: KakaoStrategy,
+    private readonly appleStrategy: AppleStrategy,
   ) {}
 
   async getUserInfo(provider: Provider, token: string): Promise<OauthUserInfo> {
@@ -16,10 +19,6 @@ export class OauthContext {
       ? await this.googleStrategy.getUserInfo(token)
       : provider === 'KAKAO'
       ? await this.kakaoStrategy.getUserInfo(token)
-      : {
-          email: 'apple-not-imple',
-          name: 'name',
-          provider: 'APPLE',
-        };
+      : await this.appleStrategy.getUserInfo(token);
   }
 }

--- a/src/infrastructure/auth/strategies/apple-strategy.ts
+++ b/src/infrastructure/auth/strategies/apple-strategy.ts
@@ -29,22 +29,6 @@ export class AppleStrategy implements OauthStrategy {
     };
   }
 
-  private async verifyToken(identifyToken: string, key: jwksClient.SigningKey) {
-    try {
-      const verfiedToken: Payload = await this.jwtService.verifyAsync(
-        identifyToken,
-        {
-          secret: key.getPublicKey(),
-          algorithms: ['RS256'],
-        },
-      );
-
-      return verfiedToken;
-    } catch (e: unknown) {
-      throw new Error(`invalid token cause: ${e}`);
-    }
-  }
-
   private extractKidFromHeader(identifyToken: string) {
     try {
       const decoded: DecodedIdentifyToken = this.jwtService.decode(
@@ -62,6 +46,22 @@ export class AppleStrategy implements OauthStrategy {
 
   private async getSigningKey(kid: string) {
     return await this.client.getSigningKey(kid);
+  }
+
+  private async verifyToken(identifyToken: string, key: jwksClient.SigningKey) {
+    try {
+      const verfiedToken: Payload = await this.jwtService.verifyAsync(
+        identifyToken,
+        {
+          secret: key.getPublicKey(),
+          algorithms: ['RS256'],
+        },
+      );
+
+      return verfiedToken;
+    } catch (e: unknown) {
+      throw new Error(`invalid token cause: ${e}`);
+    }
   }
 }
 

--- a/src/infrastructure/auth/strategies/apple-strategy.ts
+++ b/src/infrastructure/auth/strategies/apple-strategy.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as jwksClient from 'jwks-rsa';
+import { APPLE_KEYS_URL } from 'src/common/constant';
+import {
+  OauthStrategy,
+  OauthUserInfo,
+} from 'src/infrastructure/auth/strategies/oauth-strategy';
+
+@Injectable()
+export class AppleStrategy implements OauthStrategy {
+  private client: jwksClient.JwksClient;
+
+  constructor(private readonly jwtService: JwtService) {
+    this.client = jwksClient({
+      jwksUri: APPLE_KEYS_URL,
+    });
+  }
+
+  async getUserInfo(token: string): Promise<OauthUserInfo> {
+    const kid = this.extractKidFromHeader(token);
+    const key = await this.getSigningKey(kid);
+    const verifedData = await this.verifyToken(token, key);
+
+    return {
+      email: verifedData.email,
+      name: '',
+      provider: 'APPLE',
+    };
+  }
+
+  private async verifyToken(identifyToken: string, key: jwksClient.SigningKey) {
+    try {
+      const verfiedToken: Payload = await this.jwtService.verifyAsync(
+        identifyToken,
+        {
+          secret: key.getPublicKey(),
+          algorithms: ['RS256'],
+        },
+      );
+
+      return verfiedToken;
+    } catch (e: unknown) {
+      throw new Error(`invalid token cause: ${e}`);
+    }
+  }
+
+  private extractKidFromHeader(identifyToken: string) {
+    try {
+      const decoded: DecodedIdentifyToken = this.jwtService.decode(
+        identifyToken,
+        {
+          complete: true,
+        },
+      );
+
+      return decoded.header.kid;
+    } catch (e: unknown) {
+      throw new Error(`invalid token cause: ${e}`);
+    }
+  }
+
+  private async getSigningKey(kid: string) {
+    return await this.client.getSigningKey(kid);
+  }
+}
+
+interface DecodedIdentifyToken {
+  header: Header;
+  payload: Payload;
+}
+
+interface Header {
+  kid: string;
+  alg: string;
+}
+
+interface Payload {
+  iss: string;
+  aud: string;
+  exp: number;
+  iat: number;
+  sub: string;
+  c_hash: string;
+  email: string;
+  email_verified: boolean;
+  is_private_email: boolean;
+  auth_time: number;
+  nonce_supported: true;
+}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { AuthService } from 'src/domain/services/auth/auth.service';
 import { OauthContext } from 'src/infrastructure/auth/context/oauth-context';
+import { AppleStrategy } from 'src/infrastructure/auth/strategies/apple-strategy';
 import { GoogleStrategy } from 'src/infrastructure/auth/strategies/google-strategy';
 import { KakaoStrategy } from 'src/infrastructure/auth/strategies/kakao-strategy';
 import { RefreshTokenComponentModule } from 'src/modules/token/refresh-token-component.module';
@@ -24,7 +25,13 @@ import { AuthController } from 'src/presentation/controllers/auth/auth.controlle
     RefreshTokenComponentModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, OauthContext, GoogleStrategy, KakaoStrategy],
+  providers: [
+    AuthService,
+    OauthContext,
+    GoogleStrategy,
+    KakaoStrategy,
+    AppleStrategy,
+  ],
   exports: [AuthService],
 })
 export class AuthModule {}


### PR DESCRIPTION
## 변경 사항
- 애플 로그인 구현 (다른 로그인들과 플로우 다름)
  1. token decode
  2. 헤더에 있는 kid로 애플 rsa 공개키 습득
  3. 공개키로 token verify
  4. 데이터 응답
  - decode만 해도 가입 플로우는 진행 가능하지만 검증하는 편이 안전함.