### PR TITLE
친구 공개 피드에서 탈퇴한 회원의 게시글이 조회되는 문제 해결

### DIFF
--- a/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
+++ b/src/infrastructure/repositories/feed/feeds-prisma.repository.ts
@@ -211,6 +211,8 @@ export class FeedsPrismaRepository implements FeedsRepository {
             eb('f.id', 'in', (qb) =>
               qb
                 .selectFrom('friend_feed_visibility as fv')
+                .innerJoin('active_feed as f', 'f.id', 'fv.feed_id')
+                .innerJoin('active_user as u', 'u.id', 'f.writer_id')
                 .select('fv.feed_id')
                 .where('fv.user_id', '=', userIdUuid),
             ),


### PR DESCRIPTION
## 변경 사항
- 친구 공개 피드 중 탈퇴한 회원의 피드가 조회되는 현상.
  - 피드 아이디 배열을 반환하는 서브쿼리에서는 조회가 되었지만, 본쿼리에서 active user 필터링 코드 때문에 결과에는 나오지 않았었음.
  -> 결과에 노출되지 않았지만, 해당 피드 때문에 limit 수가 채워지지 않아 다음 피드가 조회되지 않았음.
```ts
          eb('f.id', 'in', (qb) =>
              qb
                .selectFrom('friend_feed_visibility as fv')
                .innerJoin('active_feed as f', 'f.id', 'fv.feed_id') // writer를 join하기 위함 ✅
                .innerJoin('active_user as u', 'u.id', 'f.writer_id') // 탈퇴한 회원의 삭제되지 않은 피드 필터링 추가 ✅
                .select('fv.feed_id')
                .where('fv.user_id', '=', userIdUuid),
            ),
```

## 특이 사항
- 이런 경우를 대비해서 서브 쿼리에서 반환한 id 배열에 in으로 검색하는 본 쿼리에는 삭제 방어 코드를 제거할까 고민 중.
-> 탈퇴한 회원의 데이터가 나오는 것보다, 노출되진 않지만 내부적으로 조회되는 데이터로 인해 다음 데이터가 조회되지 않는 현상이 리스크가 훨씬 큼.
-> 내부적으로 조회되는 데이터는 찾기도 불편함, 노출되어야할 컨텐츠가 유저한테 노출 안 됨.