### PR TITLE
애플 로그인 탈퇴 프로세스 추가 및 애플 회원 식별 값 변경

### DIFF
--- a/src/configs/config-module/validation.ts
+++ b/src/configs/config-module/validation.ts
@@ -3,23 +3,34 @@ import * as Joi from 'joi';
 export const validationSchema = Joi.object({
   // DB
   DATABASE_URL: Joi.string().required(),
+
   // AWS Cloudwatch
   CLOUDWATCH_LOG_GROUP: Joi.string().required(),
   CLOUDWATCH_LOG_STREAM: Joi.string().required(),
   CLOUDWATCH_REGION: Joi.string().required(),
   CLOUDWATCH_KEY_ID: Joi.string().required(),
   CLOUDWATCH_SECRET_KEY: Joi.string().required(),
+
   // AWS S3
   AWS_BUCKET_REGION: Joi.string().required(),
   AWS_ACCESS_KEY_ID: Joi.string().required(),
   AWS_SECRET_ACCESS_KEY: Joi.string().required(),
   AWS_BUCKEY_NAME: Joi.string().required(),
+
   // JWT
   JWT_SECRET_KEY: Joi.string().required(),
   ACCESS_TOKEN_EXPIRE: Joi.string().required(),
   REFRESH_TOKEN_EXPIRE: Joi.string().required(),
+
   //Sentry
   DSN: Joi.string().required(),
+
+  // Apple
+  APPLE_KEY_ID: Joi.string().required(),
+  APPLE_TEAM_ID: Joi.string().required(),
+  APPLE_CLIENT_ID: Joi.string().required(),
+  APPLE_PRIVATE_KEY: Joi.string().required(),
+
   // FCM
   FCM_PROJECT_ID: Joi.string().required(),
   FCM_PRIVATE_KEY: Joi.string().required(),

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -1,5 +1,7 @@
 import { Transactional } from '@nestjs-cls/transactional';
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { URLSearchParams } from 'node:url';
 import { RefreshTokenWriter } from 'src/domain/components/token/refresh-token-writer';
 import { UsersReader } from 'src/domain/components/user/users-reader';
 import { UsersWriter } from 'src/domain/components/user/users-writer';
@@ -14,6 +16,7 @@ export class UsersService {
     private readonly usersReader: UsersReader,
     private readonly usersWriter: UsersWriter,
     private readonly refreshTokenWriter: RefreshTokenWriter,
+    private readonly jwtService: JwtService,
   ) {}
 
   async changeProfileImage(userId: string, profileImageUrl: string) {
@@ -63,9 +66,59 @@ export class UsersService {
     }
   }
 
+  async withdraw(userId: string, authorizationCode?: string) {
+    if (authorizationCode) {
+      const clientSecret = this.generateAppleClientSecret();
+
+      const params = new URLSearchParams();
+      params.append('client_id', process.env.APPLE_CLIENT_ID!);
+      params.append('client_secret', clientSecret);
+      params.append('token', authorizationCode);
+      params.append('token_type_hint', 'access_token');
+
+      const revokeResponse = await fetch(
+        'https://appleid.apple.com/auth/revoke',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        },
+      );
+
+      if (!revokeResponse.ok) throw new Error('리보크 실패');
+    }
+
+    await this.withdrawTransaction(userId);
+  }
+
   @Transactional()
-  async withdraw(userId: string) {
+  async withdrawTransaction(userId: string) {
     await this.usersWriter.delete(userId);
     await this.refreshTokenWriter.deleteAll(userId);
+  }
+
+  // TODO 추후 다른 클래스로 위임 예정
+  private generateAppleClientSecret(): string {
+    const keyId = process.env.APPLE_KEY_ID;
+    const teamId = process.env.APPLE_TEAM_ID;
+    const clientId = process.env.APPLE_CLIENT_ID;
+
+    const now = Math.floor(Date.now() / 1000);
+
+    const payload = {
+      iss: teamId,
+      iat: now,
+      exp: now + 3600 * 24 * 1,
+      aud: 'https://appleid.apple.com',
+      sub: clientId,
+    };
+
+    const privateKey = process.env.APPLE_PRIVATE_KEY;
+
+    return this.jwtService.sign(payload, {
+      algorithm: 'ES256',
+      keyid: keyId,
+      secret: privateKey,
+    });
   }
 }

--- a/src/infrastructure/auth/strategies/apple-strategy.ts
+++ b/src/infrastructure/auth/strategies/apple-strategy.ts
@@ -23,7 +23,7 @@ export class AppleStrategy implements OauthStrategy {
     const verifedData = await this.verifyToken(token, key);
 
     return {
-      email: verifedData.email,
+      email: verifedData.sub,
       name: '',
       provider: 'APPLE',
     };

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -48,6 +48,7 @@ import { UsersService } from 'src/domain/services/user/users.service';
 import { S3PresignedManager } from 'src/infrastructure/aws/s3/s3-presigned-manager';
 import { PresignedUrlResponse } from 'src/presentation/dto/file/response/presigned-url.response';
 import { cookieOptions } from 'src/configs/cookie/refresh-token-cookie.config';
+import { WithdrawRequest } from 'src/presentation/dto/user/request/withdraw.request';
 
 @ApiTags('/users')
 @ApiResponse({ status: 400, description: '입력값 검증 실패' })
@@ -238,9 +239,11 @@ export class UsersController {
   @Delete()
   async withdraw(
     @CurrentUser() userId: string,
+    @Body() dto: WithdrawRequest,
     @Res({ passthrough: true }) res: Response,
   ) {
-    await this.usersService.withdraw(userId);
+    const { authorizationCode } = dto;
+    await this.usersService.withdraw(userId, authorizationCode);
     res.clearCookie('refresh_token', cookieOptions);
   }
 }

--- a/src/presentation/dto/user/request/withdraw.request.ts
+++ b/src/presentation/dto/user/request/withdraw.request.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional } from 'class-validator';
+
+export class WithdrawRequest {
+  @ApiProperty({
+    description: '애플 로그인으로 가입된 회원일 경우에만 사용.',
+  })
+  @IsOptional()
+  readonly authorizationCode?: string;
+}

--- a/test/unit/service/users.service.unit-spec.ts
+++ b/test/unit/service/users.service.unit-spec.ts
@@ -1,8 +1,11 @@
 import { UnprocessableEntityException } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ClsModule } from 'nestjs-cls';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { clsOptions } from 'src/configs/cls/cls-options';
+import { validationSchema } from 'src/configs/config-module/validation';
 import { RefreshTokenEntity } from 'src/domain/entities/token/refresh-token.entity';
 import { DuplicateAccountIdException } from 'src/domain/error/exceptions/conflice.exception';
 import { ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE } from 'src/domain/error/messages';
@@ -22,6 +25,20 @@ describe('UsersService', () => {
       imports: [
         UsersComponentModule,
         UsersModule,
+        // TODO 다른 클래스로 관련 기능 위임 후 제거
+        ConfigModule.forRoot({
+          isGlobal: true,
+          validationSchema,
+        }),
+        JwtModule.registerAsync({
+          global: true,
+          inject: [ConfigService],
+          useFactory: (config: ConfigService) => {
+            return {
+              secret: config.get<string>('JWT_SECRET_KEY'),
+            };
+          },
+        }),
         ClsModule.forRoot(clsOptions),
         PrismaModule,
       ],


### PR DESCRIPTION
## 변경 사항
- 애플 로그인으로 가입하는 회원의 식별 값을 기존 email에서 sub로 변경
  - email은 최초 로그인 시에만 제공함.
- 애플 회원 탈퇴 시 애플에 revoke api 요청을 보내야함. 따라서 해당 과정 추가.