### PR TITLE
애플 탈퇴 프로세스 추가 및 애플 회원 식별 값 변경

### DIFF
--- a/src/domain/components/token/refresh-token-writer.ts
+++ b/src/domain/components/token/refresh-token-writer.ts
@@ -20,4 +20,8 @@ export class RefreshTokenWriter {
   async delete(userId: string, deviceId: string) {
     await this.refreshTokenRepository.delete(userId, deviceId);
   }
+
+  async deleteAll(userId: string) {
+    await this.refreshTokenRepository.deleteAll(userId);
+  }
 }

--- a/src/domain/interface/token/refresh-token.repository.ts
+++ b/src/domain/interface/token/refresh-token.repository.ts
@@ -9,6 +9,7 @@ export interface RefreshTokenRepository {
   ): Promise<RefreshToken | null>;
   update(userId: string, deviceId: string, token: string): Promise<void>;
   delete(userId: string, deviceId: string): Promise<void>;
+  deleteAll(userId: string): Promise<void>;
 }
 
 export const RefreshTokenRepository = Symbol('RefreshTokenRepository');

--- a/src/domain/services/user/users.service.ts
+++ b/src/domain/services/user/users.service.ts
@@ -1,4 +1,6 @@
+import { Transactional } from '@nestjs-cls/transactional';
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { RefreshTokenWriter } from 'src/domain/components/token/refresh-token-writer';
 import { UsersReader } from 'src/domain/components/user/users-reader';
 import { UsersWriter } from 'src/domain/components/user/users-writer';
 import { DuplicateAccountIdException } from 'src/domain/error/exceptions/conflice.exception';
@@ -11,6 +13,7 @@ export class UsersService {
   constructor(
     private readonly usersReader: UsersReader,
     private readonly usersWriter: UsersWriter,
+    private readonly refreshTokenWriter: RefreshTokenWriter,
   ) {}
 
   async changeProfileImage(userId: string, profileImageUrl: string) {
@@ -58,5 +61,11 @@ export class UsersService {
       }
       throw e;
     }
+  }
+
+  @Transactional()
+  async withdraw(userId: string) {
+    await this.usersWriter.delete(userId);
+    await this.refreshTokenWriter.deleteAll(userId);
   }
 }

--- a/src/infrastructure/repositories/token/refresh-token-prisma.repository.ts
+++ b/src/infrastructure/repositories/token/refresh-token-prisma.repository.ts
@@ -57,4 +57,12 @@ export class RefreshTokenPrismaRepository implements RefreshTokenRepository {
       },
     });
   }
+
+  async deleteAll(userId: string): Promise<void> {
+    await this.prisma.refreshToken.deleteMany({
+      where: {
+        userId,
+      },
+    });
+  }
 }

--- a/src/modules/user/users.module.ts
+++ b/src/modules/user/users.module.ts
@@ -3,8 +3,9 @@ import { UsersController } from 'src/presentation/controllers/user/users.control
 import { UsersComponentModule } from 'src/modules/user/usesr.component.module';
 import { UsersService } from 'src/domain/services/user/users.service';
 import { S3Module } from 'src/infrastructure/aws/s3/s3.module';
+import { RefreshTokenComponentModule } from 'src/modules/token/refresh-token-component.module';
 @Module({
-  imports: [UsersComponentModule, S3Module],
+  imports: [S3Module, UsersComponentModule, RefreshTokenComponentModule],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -237,7 +237,7 @@ export class UsersController {
   @UseGuards(AuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   @Delete()
-  async delete(@CurrentUser() userId: string) {
-    await this.usersWriter.delete(userId);
+  async withdraw(@CurrentUser() userId: string) {
+    await this.usersService.withdraw(userId);
   }
 }

--- a/src/presentation/controllers/user/users.controller.ts
+++ b/src/presentation/controllers/user/users.controller.ts
@@ -8,11 +8,13 @@ import {
   Patch,
   Post,
   Query,
+  Res,
   UploadedFile,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { Response } from 'express';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -45,6 +47,7 @@ import { UsersReader } from 'src/domain/components/user/users-reader';
 import { UsersService } from 'src/domain/services/user/users.service';
 import { S3PresignedManager } from 'src/infrastructure/aws/s3/s3-presigned-manager';
 import { PresignedUrlResponse } from 'src/presentation/dto/file/response/presigned-url.response';
+import { cookieOptions } from 'src/configs/cookie/refresh-token-cookie.config';
 
 @ApiTags('/users')
 @ApiResponse({ status: 400, description: '입력값 검증 실패' })
@@ -224,11 +227,7 @@ export class UsersController {
     await this.usersWriter.updateNotificationToken(dto.token, userId);
   }
 
-  @ApiOperation({
-    summary: '탈퇴',
-    description:
-      '아직 실행은 하면 안 돼여, 삭제 정책 다른 곳에 반영 안 했어요~~',
-  })
+  @ApiOperation({ summary: '탈퇴' })
   @ApiResponse({
     status: 204,
     description: '탈퇴 성공',
@@ -237,7 +236,11 @@ export class UsersController {
   @UseGuards(AuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   @Delete()
-  async withdraw(@CurrentUser() userId: string) {
+  async withdraw(
+    @CurrentUser() userId: string,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     await this.usersService.withdraw(userId);
+    res.clearCookie('refresh_token', cookieOptions);
   }
 }

--- a/test/unit/service/users.service.unit-spec.ts
+++ b/test/unit/service/users.service.unit-spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ClsModule } from 'nestjs-cls';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { clsOptions } from 'src/configs/cls/cls-options';
+import { RefreshTokenEntity } from 'src/domain/entities/token/refresh-token.entity';
 import { DuplicateAccountIdException } from 'src/domain/error/exceptions/conflice.exception';
 import { ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE } from 'src/domain/error/messages';
 import { UsersService } from 'src/domain/services/user/users.service';
@@ -12,7 +13,7 @@ import { UsersModule } from 'src/modules/user/users.module';
 import { UsersComponentModule } from 'src/modules/user/usesr.component.module';
 import { generateUserEntity } from 'test/helpers/generators';
 
-describe('FriendsService', () => {
+describe('UsersService', () => {
   let usersService: UsersService;
   let db: PrismaService;
 
@@ -66,74 +67,96 @@ describe('FriendsService', () => {
       expect(updatedUser).not.toBeNull();
       expect(updatedUser?.accountId).toEqual(newAccountId);
     });
-  });
 
-  it('마지막 변경일로부터 30일이 지나지 않은 경우 예외가 발생한다', async () => {
-    const updatedAt = new Date(2025, 1, 2);
-    const user = generateUserEntity(
-      'test@test.com',
-      'account_id',
-      '민수',
-      'https://image.com',
-      'GOOGLE',
-      new Date(),
-      updatedAt,
-    );
-    await db.user.create({ data: user });
+    it('마지막 변경일로부터 30일이 지나지 않은 경우 예외가 발생한다', async () => {
+      const updatedAt = new Date(2025, 1, 2);
+      const user = generateUserEntity(
+        'test@test.com',
+        'account_id',
+        '민수',
+        'https://image.com',
+        'GOOGLE',
+        new Date(),
+        updatedAt,
+      );
+      await db.user.create({ data: user });
 
-    const today = new Date(2025, 1, 31);
-    const newAccountId = 'new_id';
+      const today = new Date(2025, 1, 31);
+      const newAccountId = 'new_id';
 
-    await expect(
-      async () =>
-        await usersService.changeAccountId(user.id, newAccountId, today),
-    ).rejects.toThrow(
-      new UnprocessableEntityException(ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE(1)),
-    );
-  });
-
-  it('프로필 사진 변경은 계정 아이디 변경에 영향을 주어선 안 된다', async () => {
-    const createdAt = new Date(2025, 1, 1);
-    const user = generateUserEntity(
-      'test@test.com',
-      'account_id',
-      '민수',
-      'https://image.com',
-      'GOOGLE',
-      createdAt,
-      createdAt,
-    );
-    await db.user.create({ data: user });
-
-    const today = new Date(2025, 1, 31);
-    const newProfileImage = 'https://newimage.com';
-    const newAccountId = 'new_id';
-
-    await usersService.changeProfileImage(user.id, newProfileImage);
-    await usersService.changeAccountId(user.id, newAccountId, today);
-    const updatedUser = await db.user.findFirst({
-      where: { accountId: newAccountId },
+      await expect(
+        async () =>
+          await usersService.changeAccountId(user.id, newAccountId, today),
+      ).rejects.toThrow(
+        new UnprocessableEntityException(ACCOUNT_ID_CHANGE_COOLDOWN_MESSAGE(1)),
+      );
     });
 
-    expect(updatedUser).not.toBeNull();
-    expect(updatedUser?.accountId).toEqual(newAccountId);
-  });
+    it('프로필 사진 변경은 계정 아이디 변경에 영향을 주어선 안 된다', async () => {
+      const createdAt = new Date(2025, 1, 1);
+      const user = generateUserEntity(
+        'test@test.com',
+        'account_id',
+        '민수',
+        'https://image.com',
+        'GOOGLE',
+        createdAt,
+        createdAt,
+      );
+      await db.user.create({ data: user });
 
-  it('탈퇴한지 30일이 지나지 않은 동일한 아이디의 회원이 존재하는 경우 예외가 발생한다.', async () => {
-    const user = generateUserEntity('test@test.com', 'account_id');
-    await db.user.create({ data: user });
+      const today = new Date(2025, 1, 31);
+      const newProfileImage = 'https://newimage.com';
+      const newAccountId = 'new_id';
 
-    const newAccountId = 'new_account_id';
+      await usersService.changeProfileImage(user.id, newProfileImage);
+      await usersService.changeAccountId(user.id, newAccountId, today);
+      const updatedUser = await db.user.findFirst({
+        where: { accountId: newAccountId },
+      });
 
-    const deletedUser = generateUserEntity('test@test.com', newAccountId);
-    await db.user.create({ data: deletedUser });
-    await db.user.update({
-      data: { deletedAt: new Date(Date.now() - 29 * 24 * 60 * 60 * 1000) },
-      where: { id: deletedUser.id },
+      expect(updatedUser).not.toBeNull();
+      expect(updatedUser?.accountId).toEqual(newAccountId);
     });
 
-    await expect(
-      async () => await usersService.changeAccountId(user.id, newAccountId),
-    ).rejects.toThrow(new DuplicateAccountIdException());
+    it('탈퇴한지 30일이 지나지 않은 동일한 아이디의 회원이 존재하는 경우 예외가 발생한다.', async () => {
+      const user = generateUserEntity('test@test.com', 'account_id');
+      await db.user.create({ data: user });
+
+      const newAccountId = 'new_account_id';
+
+      const deletedUser = generateUserEntity('test@test.com', newAccountId);
+      await db.user.create({ data: deletedUser });
+      await db.user.update({
+        data: { deletedAt: new Date(Date.now() - 29 * 24 * 60 * 60 * 1000) },
+        where: { id: deletedUser.id },
+      });
+
+      await expect(
+        async () => await usersService.changeAccountId(user.id, newAccountId),
+      ).rejects.toThrow(new DuplicateAccountIdException());
+    });
+  });
+
+  describe('회원 탈퇴', () => {
+    it('탈퇴 시 회원은 삭제 처리되고 해당 회원의 모든 토큰이 삭제된다.', async () => {
+      const user = await db.user.create({
+        data: generateUserEntity('me@test.com', 'mememem'),
+      });
+      const refreshTokens = Array.from({ length: 5 }, (_, i) =>
+        RefreshTokenEntity.create(
+          { deviceId: `device${i}`, token: `token${i}`, userId: user.id },
+          new Date(),
+        ),
+      );
+      await db.refreshToken.createMany({ data: refreshTokens });
+
+      await usersService.withdraw(user.id);
+      const deletedTokens = await db.refreshToken.findMany();
+      const deletedUser = (await db.user.findMany())[0];
+
+      expect(deletedUser.deletedAt).not.toBeNull();
+      expect(deletedTokens.length).toEqual(0);
+    });
   });
 });


### PR DESCRIPTION
- 애플 로그인으로 가입하는 회원의 식별 값을 기존 email에서 sub로 변경
  - email은 최초 로그인 시에만 제공함.
- 애플 회원 탈퇴 시 애플에 revoke api 요청을 보내야함. 따라서 해당 과정 추가.